### PR TITLE
Add AGENTS.md for development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,16 +2,22 @@
 
 ## Cursor Cloud specific instructions
 
-**CookieCut** is a zero-dependency, client-side-only recipe builder. The entire app is 3 files: `index.html`, `app.js`, `styles.css`. There is no package manager, build step, test framework, or linter.
+**CookieCut** is a zero-dependency, client-side-only recipe builder. There is no package manager, build step, test framework, or linter.
+
+### Architecture
+- `index.html` is a minimal shell; `app.js` (ES module entry point) fetches HTML partials from `partials/` via `fetch()` and injects them into the DOM at runtime, then wires up event listeners.
+- JS is split into native ES modules under `js/`: `state.js` (data), `dom.js` (DOM refs), `constants.js`, `helpers.js`, `global.js` (init), `builders/classic.js`, `builders/inline.js`, and per-item-type handlers in `handlers/`.
+- `partials/imports.html` is a reference file and is **not loaded at runtime**; all CDN imports live in `index.html`'s `<head>`.
 
 ### Running the app
-Serve the repo root with any static HTTP server:
+A static HTTP server is **required** (not `file://`) because `app.js` uses `fetch()` to load partials:
 ```
 python3 -m http.server 8000
 ```
 Then open `http://localhost:8000` in Chrome.
 
 ### Key caveats
-- All external assets (Tailwind CSS, Google Fonts, Material Icons) load from CDNs at runtime. Internet access is required.
+- All external assets (Tailwind CSS via Play CDN, Google Fonts, Material Icons) load from CDNs at runtime. Internet access is required.
 - There are no automated tests, no lint config, and no build command. Verification is manual-only via the browser.
-- State is in-memory only (`recipeData` object in `app.js`); nothing persists across page reloads.
+- State is in-memory only (`recipeData` in `js/state.js`); nothing persists across page reloads.
+- CI: `.github/workflows/preview.yml` deploys PR preview channels to Firebase Hosting (project `slf-cookiecutter`). No build step runs in CI — raw files are deployed directly.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for the CookieCut development environment, updated for the new modular architecture.

## Changes

- Created `AGENTS.md` documenting:
  - The modular ES module architecture (`js/` directory with builders, handlers, state, dom, helpers, constants)
  - HTML partials loaded at runtime via `fetch()` from `partials/`
  - How to run the app (static HTTP server required due to `fetch()` usage)
  - Key caveats: CDN dependencies, no tests/lint/build, in-memory state, Firebase CI/CD

## Context

CookieCut is a zero-dependency, client-side-only static web application recently restructured from a monolithic 3-file setup into a modular architecture with ES modules and HTML partials. No package manager, build step, test framework, or linter exists. The app is served via any static HTTP server (e.g., `python3 -m http.server 8000`) and tested manually in the browser.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-461bc368-ab56-40d8-a37c-52dc8d7a0543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-461bc368-ab56-40d8-a37c-52dc8d7a0543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

