### PR TITLE
Add bulleted list item support in classic and inline previews

### DIFF
--- a/js/builders/classic.js
+++ b/js/builders/classic.js
@@ -1,82 +1,89 @@
-import { recipeData } from '../state.js';
-import { dom } from '../dom.js';
-import { renderIconCodes } from '../helpers.js';
-import * as headingHandler from '../handlers/heading.js';
-import * as stepHandler from '../handlers/step.js';
-import { getBuilderInput as getBulletBuilderInput, renderPreviewElement as renderBulletPreviewElement } from '../handlers/bullet.js';
-import * as textHandler from '../handlers/text.js';
-import * as imageHandler from '../handlers/image.js';
-import * as bubbleHandler from '../handlers/bubble.js';
-import { getBuilderInput as getLinkBuilderInput, renderPreviewElement as renderLinkPreviewElement } from '../handlers/link.js';
+import { recipeData } from '../state.js'
+import { dom } from '../dom.js'
+import { renderIconCodes } from '../helpers.js'
+import * as headingHandler from '../handlers/heading.js'
+import * as stepHandler from '../handlers/step.js'
+import {
+  getBuilderInput as getBulletBuilderInput,
+  renderPreviewElement as renderBulletPreviewElement
+} from '../handlers/bullet.js'
+import * as textHandler from '../handlers/text.js'
+import * as imageHandler from '../handlers/image.js'
+import * as bubbleHandler from '../handlers/bubble.js'
+import {
+  getBuilderInput as getLinkBuilderInput,
+  renderPreviewElement as renderLinkPreviewElement
+} from '../handlers/link.js'
 // Note: renderInlinePreview is imported lazily inside the function body to avoid
 // circular-import issues at module evaluation time.
-let inlineRenderRequestId = 0;
+let inlineRenderRequestId = 0
 
 /**
  * Re-draws the entire builder input form based on recipeData.
  */
-export function renderBuilderInputs() {
-    dom.contentInputs.innerHTML = '';
+export function renderBuilderInputs () {
+  dom.contentInputs.innerHTML = ''
 
-    recipeData.items.forEach((item, index) => {
-        const el = document.createElement('div');
-        el.setAttribute('data-id', item.id);
-        el.className = 'p-4 bg-white border border-gray-300 rounded-lg shadow-sm animate-fade-in-down';
+  recipeData.items.forEach((item, index) => {
+    const el = document.createElement('div')
+    el.setAttribute('data-id', item.id)
+    el.className =
+      'p-4 bg-white border border-gray-300 rounded-lg shadow-sm animate-fade-in-down'
 
-        let inputHtml = '';
-        let itemLabel = '';
+    let inputHtml = ''
+    let itemLabel = ''
 
-        switch (item.type) {
-            case 'heading': {
-                const result = headingHandler.getBuilderInput(item);
-                itemLabel = result.label;
-                inputHtml = result.inputHtml;
-                break;
-            }
-            case 'step': {
-                const result = stepHandler.getBuilderInput(item);
-                itemLabel = result.label;
-                inputHtml = result.inputHtml;
-                break;
-            }
-            case 'bullet': {
-                const result = getBulletBuilderInput(item);
-                itemLabel = result.label;
-                inputHtml = result.inputHtml;
-                break;
-            }
-            case 'text': {
-                const result = textHandler.getBuilderInput(item);
-                itemLabel = result.label;
-                inputHtml = result.inputHtml;
-                break;
-            }
-            case 'image': {
-                const result = imageHandler.getBuilderInput(item);
-                itemLabel = result.label;
-                inputHtml = result.inputHtml;
-                break;
-            }
-            case 'bubble': {
-                const result = bubbleHandler.getBuilderInput(item);
-                itemLabel = result.label;
-                inputHtml = result.inputHtml;
-                break;
-            }
-            case 'link': {
-                const result = getLinkBuilderInput(item);
-                itemLabel = result.label;
-                inputHtml = result.inputHtml;
-                break;
-            }
-            default:
-                break;
-        }
+    switch (item.type) {
+      case 'heading': {
+        const result = headingHandler.getBuilderInput(item)
+        itemLabel = result.label
+        inputHtml = result.inputHtml
+        break
+      }
+      case 'step': {
+        const result = stepHandler.getBuilderInput(item)
+        itemLabel = result.label
+        inputHtml = result.inputHtml
+        break
+      }
+      case 'bullet': {
+        const result = getBulletBuilderInput(item)
+        itemLabel = result.label
+        inputHtml = result.inputHtml
+        break
+      }
+      case 'text': {
+        const result = textHandler.getBuilderInput(item)
+        itemLabel = result.label
+        inputHtml = result.inputHtml
+        break
+      }
+      case 'image': {
+        const result = imageHandler.getBuilderInput(item)
+        itemLabel = result.label
+        inputHtml = result.inputHtml
+        break
+      }
+      case 'bubble': {
+        const result = bubbleHandler.getBuilderInput(item)
+        itemLabel = result.label
+        inputHtml = result.inputHtml
+        break
+      }
+      case 'link': {
+        const result = getLinkBuilderInput(item)
+        itemLabel = result.label
+        inputHtml = result.inputHtml
+        break
+      }
+      default:
+        break
+    }
 
-        const isFirst = index === 0;
-        const isLast = index === recipeData.items.length - 1;
+    const isFirst = index === 0
+    const isLast = index === recipeData.items.length - 1
 
-        el.innerHTML = `
+    el.innerHTML = `
             <div class="flex justify-between items-center mb-2">
                 <label class="font-bold text-gray-700">${itemLabel}</label>
                 <div class="flex items-center space-x-3">
@@ -86,108 +93,139 @@ export function renderBuilderInputs() {
                 </div>
             </div>
             ${inputHtml}
-        `;
-        dom.contentInputs.appendChild(el);
-    });
+        `
+    dom.contentInputs.appendChild(el)
+  })
 
-    // If inline editor is active, update its preview too
-    if (recipeData.settings && recipeData.settings.editorMode === 'inline') {
-        const requestId = ++inlineRenderRequestId;
-        // Import lazily to avoid circular dependency at evaluation time
-        import('./inline.js').then(({ renderInlinePreview }) => {
-            if (requestId !== inlineRenderRequestId) return;
-            if (!recipeData.settings || recipeData.settings.editorMode !== 'inline') return;
-            renderInlinePreview();
-        }).catch((error) => {
-            // Handle failures to load the inline builder module gracefully
-            console.error('Failed to load inline builder module:', error);
-            // Invalidate this request if it is still the active one
-            if (requestId === inlineRenderRequestId) {
-                inlineRenderRequestId += 1;
-            }
-        });
-    } else {
-        // invalidate queued inline rerenders after mode flips to classic
-        inlineRenderRequestId += 1;
-    }
+  // If inline editor is active, update its preview too
+  if (recipeData.settings && recipeData.settings.editorMode === 'inline') {
+    const requestId = ++inlineRenderRequestId
+    // Import lazily to avoid circular dependency at evaluation time
+    import('./inline.js')
+      .then(({ renderInlinePreview }) => {
+        if (requestId !== inlineRenderRequestId) return
+        if (
+          !recipeData.settings ||
+          recipeData.settings.editorMode !== 'inline'
+        ) {
+          return
+        }
+        renderInlinePreview()
+      })
+      .catch((error) => {
+        // Handle failures to load the inline builder module gracefully
+        console.error('Failed to load inline builder module:', error)
+        // Invalidate this request if it is still the active one
+        if (requestId === inlineRenderRequestId) {
+          inlineRenderRequestId += 1
+        }
+      })
+  } else {
+    // invalidate queued inline rerenders after mode flips to classic
+    inlineRenderRequestId += 1
+  }
 }
 
 /**
  * Re-draws the entire recipe preview based on recipeData.
  */
-export function renderPreview() {
-    const fontStyle = recipeData.settings.fontStyle || 'display';
+export function renderPreview () {
+  const fontStyle = recipeData.settings.fontStyle || 'display'
 
-    dom.titlePreview.innerHTML = renderIconCodes(recipeData.title);
-    dom.titlePreview.className = `font-style-${fontStyle}`;
+  dom.titlePreview.innerHTML = renderIconCodes(recipeData.title)
+  dom.titlePreview.className = `font-style-${fontStyle}`
 
-    dom.descPreview.innerHTML = renderIconCodes(recipeData.description);
-    dom.contentPreview.innerHTML = '';
+  dom.descPreview.innerHTML = renderIconCodes(recipeData.description)
+  dom.contentPreview.innerHTML = ''
 
-    let currentList = null;
-    let currentListType = null;
+  let currentList = null
+  let currentListType = null
 
-    recipeData.items.forEach(item => {
-        const isListItem = item.type === 'step' || item.type === 'bullet';
+  recipeData.items.forEach((item) => {
+    const isListItem = item.type === 'step' || item.type === 'bullet'
 
-        if ((!isListItem || currentListType !== item.type) && currentList) {
-            dom.contentPreview.appendChild(currentList);
-            currentList = null;
-            currentListType = null;
-        }
-
-        const contentWithIcons = renderIconCodes(item.content || '');
-
-        switch (item.type) {
-            case 'heading': {
-                const el = headingHandler.renderPreviewElement(item, fontStyle, contentWithIcons);
-                dom.contentPreview.appendChild(el);
-                break;
-            }
-            case 'step': {
-                if (!currentList) {
-                    currentList = document.createElement('ol');
-                    currentListType = 'step';
-                }
-                const el = stepHandler.renderPreviewElement(item, fontStyle, contentWithIcons);
-                currentList.appendChild(el);
-                break;
-            }
-            case 'bullet': {
-                if (!currentList) {
-                    currentList = document.createElement('ul');
-                    currentListType = 'bullet';
-                }
-                const el = renderBulletPreviewElement(item, fontStyle, contentWithIcons);
-                currentList.appendChild(el);
-                break;
-            }
-            case 'text': {
-                const el = textHandler.renderPreviewElement(item, fontStyle, contentWithIcons);
-                dom.contentPreview.appendChild(el);
-                break;
-            }
-            case 'image': {
-                const el = imageHandler.renderPreviewElement(item, fontStyle, contentWithIcons);
-                dom.contentPreview.appendChild(el);
-                break;
-            }
-            case 'bubble': {
-                const el = bubbleHandler.renderPreviewElement(item, fontStyle, contentWithIcons);
-                dom.contentPreview.appendChild(el);
-                break;
-            }
-            case 'link': {
-                const el = renderLinkPreviewElement(item, fontStyle, contentWithIcons);
-                dom.contentPreview.appendChild(el);
-                break;
-            }
-            default:
-                break;
-        }
-    });
-
-    if (currentList) {
-        dom.contentPreview.appendChild(currentList);
+    if ((!isListItem || currentListType !== item.type) && currentList) {
+      dom.contentPreview.appendChild(currentList)
+      currentList = null
+      currentListType = null
     }
+
+    const contentWithIcons = renderIconCodes(item.content || '')
+
+    switch (item.type) {
+      case 'heading': {
+        const el = headingHandler.renderPreviewElement(
+          item,
+          fontStyle,
+          contentWithIcons
+        )
+        dom.contentPreview.appendChild(el)
+        break
+      }
+      case 'step': {
+        if (!currentList) {
+          currentList = document.createElement('ol')
+          currentListType = 'step'
+        }
+        const el = stepHandler.renderPreviewElement(
+          item,
+          fontStyle,
+          contentWithIcons
+        )
+        currentList.appendChild(el)
+        break
+      }
+      case 'bullet': {
+        if (!currentList) {
+          currentList = document.createElement('ul')
+          currentListType = 'bullet'
+        }
+        const el = renderBulletPreviewElement(
+          item,
+          fontStyle,
+          contentWithIcons
+        )
+        currentList.appendChild(el)
+        break
+      }
+      case 'text': {
+        const el = textHandler.renderPreviewElement(
+          item,
+          fontStyle,
+          contentWithIcons
+        )
+        dom.contentPreview.appendChild(el)
+        break
+      }
+      case 'image': {
+        const el = imageHandler.renderPreviewElement(
+          item,
+          fontStyle,
+          contentWithIcons
+        )
+        dom.contentPreview.appendChild(el)
+        break
+      }
+      case 'bubble': {
+        const el = bubbleHandler.renderPreviewElement(
+          item,
+          fontStyle,
+          contentWithIcons
+        )
+        dom.contentPreview.appendChild(el)
+        break
+      }
+      case 'link': {
+        const el = renderLinkPreviewElement(item, fontStyle, contentWithIcons)
+        dom.contentPreview.appendChild(el)
+        break
+      }
+      default:
+        break
+    }
+  })
+
+  if (currentList) {
+    dom.contentPreview.appendChild(currentList)
+  }
 }

--- a/js/builders/inline.js
+++ b/js/builders/inline.js
@@ -1,655 +1,716 @@
-import { recipeData } from '../state.js';
-import { dom } from '../dom.js';
-import { renderIconCodes, getTextAndCaret, setCaretPosition } from '../helpers.js';
-import * as headingHandler from '../handlers/heading.js';
-import * as stepHandler from '../handlers/step.js';
-import { renderInlineElement as renderInlineBulletElement } from '../handlers/bullet.js';
-import * as textHandler from '../handlers/text.js';
-import * as imageHandler from '../handlers/image.js';
-import * as bubbleHandler from '../handlers/bubble.js';
-import { renderInlineElement as renderInlineLinkElement } from '../handlers/link.js';
+import { recipeData } from '../state.js'
+import { dom } from '../dom.js'
+import {
+  renderIconCodes,
+  getTextAndCaret,
+  setCaretPosition
+} from '../helpers.js'
+import * as headingHandler from '../handlers/heading.js'
+import * as stepHandler from '../handlers/step.js'
+import { renderInlineElement as renderInlineBulletElement } from '../handlers/bullet.js'
+import * as textHandler from '../handlers/text.js'
+import * as imageHandler from '../handlers/image.js'
+import * as bubbleHandler from '../handlers/bubble.js'
+import { renderInlineElement as renderInlineLinkElement } from '../handlers/link.js'
 // renderBuilderInputs is imported lazily inside function bodies to avoid
 // circular-import issues at module evaluation time.
 
 // --- Image Resizer State ---
-let currentResizer = null;
-let currentLinkEditor = null;
-let linkEditorInputIdCounter = 0;
-let currentDeleteConfirm = null;
-let currentDeleteResolve = null;
-let currentDeleteKeydownHandler = null;
+let currentResizer = null
+let currentLinkEditor = null
+let linkEditorInputIdCounter = 0
+let currentDeleteConfirm = null
+let currentDeleteResolve = null
+let currentDeleteKeydownHandler = null
 
-function closeInlineDeleteConfirm(confirmed = false) {
-    if (currentDeleteConfirm) {
-        currentDeleteConfirm.remove();
-        currentDeleteConfirm = null;
+function closeInlineDeleteConfirm (confirmed = false) {
+  if (currentDeleteConfirm) {
+    currentDeleteConfirm.remove()
+    currentDeleteConfirm = null
+  }
+  if (currentDeleteKeydownHandler) {
+    document.removeEventListener('keydown', currentDeleteKeydownHandler)
+    currentDeleteKeydownHandler = null
+  }
+  if (currentDeleteResolve) {
+    const resolve = currentDeleteResolve
+    currentDeleteResolve = null
+    resolve(Boolean(confirmed))
+  }
+}
+
+function openInlineDeleteConfirm (message = 'Remove this item?') {
+  closeInlineDeleteConfirm(false)
+
+  return new Promise((resolve) => {
+    currentDeleteResolve = resolve
+
+    const overlay = document.createElement('div')
+    overlay.className = 'inline-delete-confirm-overlay'
+    overlay.style.position = 'fixed'
+    overlay.style.inset = '0'
+    overlay.style.zIndex = 62
+    overlay.style.background = 'rgba(0,0,0,0.45)'
+    overlay.style.display = 'flex'
+    overlay.style.alignItems = 'center'
+    overlay.style.justifyContent = 'center'
+    overlay.style.padding = '16px'
+
+    const dialog = document.createElement('div')
+    dialog.style.background = 'white'
+    dialog.style.width = 'min(360px, calc(100vw - 32px))'
+    dialog.style.borderRadius = '10px'
+    dialog.style.boxShadow = '0 14px 30px rgba(0,0,0,0.18)'
+    dialog.style.padding = '14px'
+
+    const title = document.createElement('p')
+    title.textContent = message
+    title.style.marginBottom = '12px'
+    title.style.fontSize = '14px'
+    title.style.color = '#111827'
+
+    const actions = document.createElement('div')
+    actions.style.display = 'flex'
+    actions.style.justifyContent = 'flex-end'
+    actions.style.gap = '8px'
+
+    const cancelBtn = document.createElement('button')
+    cancelBtn.textContent = 'Cancel'
+    cancelBtn.className = 'px-3 py-1 bg-gray-100 rounded'
+    cancelBtn.addEventListener('click', () => closeInlineDeleteConfirm(false))
+
+    const removeBtn = document.createElement('button')
+    removeBtn.textContent = 'Remove'
+    removeBtn.className = 'px-3 py-1 bg-red-600 text-white rounded'
+    removeBtn.addEventListener('click', () => closeInlineDeleteConfirm(true))
+
+    actions.appendChild(cancelBtn)
+    actions.appendChild(removeBtn)
+    dialog.appendChild(title)
+    dialog.appendChild(actions)
+    overlay.appendChild(dialog)
+
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) closeInlineDeleteConfirm(false)
+    })
+
+    currentDeleteKeydownHandler = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        closeInlineDeleteConfirm(false)
+      }
     }
-    if (currentDeleteKeydownHandler) {
-        document.removeEventListener('keydown', currentDeleteKeydownHandler);
-        currentDeleteKeydownHandler = null;
+    document.addEventListener('keydown', currentDeleteKeydownHandler)
+
+    document.body.appendChild(overlay)
+    currentDeleteConfirm = overlay
+    removeBtn.focus()
+  })
+}
+
+function closeActiveInlineEditors () {
+  closeImageResizer()
+  closeLinkEditor()
+  closeInlineDeleteConfirm(false)
+}
+
+function syncLinkInputs (item) {
+  const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`)
+  if (!itemEl) return
+  const contentInput = itemEl.querySelector('[data-key="content"]')
+  const hrefInput = itemEl.querySelector('[data-key="href"]')
+  if (contentInput) contentInput.value = item.content || ''
+  if (hrefInput) hrefInput.value = item.href || ''
+}
+
+function persistLinkChanges (item, text, href) {
+  item.content = text.trim()
+  item.href = href.trim()
+  syncLinkInputs(item)
+}
+
+function saveLinkAndRerender (item, text, href) {
+  persistLinkChanges(item, text, href)
+  closeLinkEditor()
+  import('./classic.js').then(({ renderBuilderInputs }) => {
+    renderBuilderInputs()
+  })
+}
+
+export function openImageResizer (imgEl, item) {
+  closeActiveInlineEditors()
+  const resizer = document.createElement('div')
+  resizer.className = 'image-resizer-overlay'
+  resizer.style.position = 'fixed'
+  resizer.style.left = '50%'
+  resizer.style.transform = 'translateX(-50%)'
+  resizer.style.bottom = '20px'
+  resizer.style.zIndex = 60
+  resizer.style.background = 'white'
+  resizer.style.padding = '8px 12px'
+  resizer.style.borderRadius = '8px'
+  resizer.style.boxShadow = '0 6px 18px rgba(0,0,0,0.12)'
+
+  const input = document.createElement('input')
+  input.type = 'range'
+  input.min = 100
+  input.max = 1200
+  input.step = 1
+  input.value = item.size || 350
+  input.style.width = '300px'
+  const label = document.createElement('span')
+  label.textContent = `${input.value}px`
+  label.style.marginLeft = '10px'
+
+  input.addEventListener('input', () => {
+    const sizeValue = input.value
+    item.size = Number(sizeValue)
+    imgEl.style.maxWidth = `${sizeValue}px`
+    label.textContent = `${sizeValue}px`
+    // update builder input display if visible
+    const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`)
+    if (itemEl) {
+      const display = itemEl.querySelector('[data-role="size-display"]')
+      const slider = itemEl.querySelector('[data-key="size"]')
+      if (display) display.textContent = `${sizeValue}px`
+      if (slider) slider.value = sizeValue
     }
-    if (currentDeleteResolve) {
-        const resolve = currentDeleteResolve;
-        currentDeleteResolve = null;
-        resolve(Boolean(confirmed));
+  })
+
+  // URL and alt inputs
+  const urlLabel = document.createElement('label')
+  urlLabel.textContent = 'Image URL'
+  urlLabel.style.display = 'block'
+  urlLabel.style.marginTop = '8px'
+  const urlInput = document.createElement('input')
+  urlInput.type = 'url'
+  urlInput.value = item.src || ''
+  urlInput.placeholder = 'https://...'
+  urlInput.style.width = '420px'
+  urlInput.style.display = 'block'
+  urlInput.style.marginTop = '4px'
+
+  const altLabel = document.createElement('label')
+  altLabel.textContent = 'Alt text'
+  altLabel.style.display = 'block'
+  altLabel.style.marginTop = '6px'
+  const altInput = document.createElement('input')
+  altInput.type = 'text'
+  altInput.value = item.alt || ''
+  altInput.style.width = '420px'
+  altInput.style.display = 'block'
+  altInput.style.marginTop = '4px'
+
+  const applyBtn = document.createElement('button')
+  applyBtn.textContent = 'Apply'
+  applyBtn.className = 'ml-3 px-3 py-1 bg-blue-600 text-white rounded'
+  applyBtn.addEventListener('click', () => {
+    const newUrl = urlInput.value.trim()
+    const newAlt = altInput.value.trim()
+    if (newUrl) {
+      item.src = newUrl
+      imgEl.src = newUrl
     }
-}
-
-function openInlineDeleteConfirm(message = 'Remove this item?') {
-    closeInlineDeleteConfirm(false);
-
-    return new Promise((resolve) => {
-        currentDeleteResolve = resolve;
-
-        const overlay = document.createElement('div');
-        overlay.className = 'inline-delete-confirm-overlay';
-        overlay.style.position = 'fixed';
-        overlay.style.inset = '0';
-        overlay.style.zIndex = 62;
-        overlay.style.background = 'rgba(0,0,0,0.45)';
-        overlay.style.display = 'flex';
-        overlay.style.alignItems = 'center';
-        overlay.style.justifyContent = 'center';
-        overlay.style.padding = '16px';
-
-        const dialog = document.createElement('div');
-        dialog.style.background = 'white';
-        dialog.style.width = 'min(360px, calc(100vw - 32px))';
-        dialog.style.borderRadius = '10px';
-        dialog.style.boxShadow = '0 14px 30px rgba(0,0,0,0.18)';
-        dialog.style.padding = '14px';
-
-        const title = document.createElement('p');
-        title.textContent = message;
-        title.style.marginBottom = '12px';
-        title.style.fontSize = '14px';
-        title.style.color = '#111827';
-
-        const actions = document.createElement('div');
-        actions.style.display = 'flex';
-        actions.style.justifyContent = 'flex-end';
-        actions.style.gap = '8px';
-
-        const cancelBtn = document.createElement('button');
-        cancelBtn.textContent = 'Cancel';
-        cancelBtn.className = 'px-3 py-1 bg-gray-100 rounded';
-        cancelBtn.addEventListener('click', () => closeInlineDeleteConfirm(false));
-
-        const removeBtn = document.createElement('button');
-        removeBtn.textContent = 'Remove';
-        removeBtn.className = 'px-3 py-1 bg-red-600 text-white rounded';
-        removeBtn.addEventListener('click', () => closeInlineDeleteConfirm(true));
-
-        actions.appendChild(cancelBtn);
-        actions.appendChild(removeBtn);
-        dialog.appendChild(title);
-        dialog.appendChild(actions);
-        overlay.appendChild(dialog);
-
-        overlay.addEventListener('click', (event) => {
-            if (event.target === overlay) closeInlineDeleteConfirm(false);
-        });
-
-        currentDeleteKeydownHandler = (event) => {
-            if (event.key === 'Escape') {
-                event.preventDefault();
-                closeInlineDeleteConfirm(false);
-            }
-        };
-        document.addEventListener('keydown', currentDeleteKeydownHandler);
-
-        document.body.appendChild(overlay);
-        currentDeleteConfirm = overlay;
-        removeBtn.focus();
-    });
-}
-
-function closeActiveInlineEditors() {
-    closeImageResizer();
-    closeLinkEditor();
-    closeInlineDeleteConfirm(false);
-}
-
-function syncLinkInputs(item) {
-    const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`);
-    if (!itemEl) return;
-    const contentInput = itemEl.querySelector('[data-key="content"]');
-    const hrefInput = itemEl.querySelector('[data-key="href"]');
-    if (contentInput) contentInput.value = item.content || '';
-    if (hrefInput) hrefInput.value = item.href || '';
-}
-
-function persistLinkChanges(item, text, href) {
-    item.content = text.trim();
-    item.href = href.trim();
-    syncLinkInputs(item);
-}
-
-function saveLinkAndRerender(item, text, href) {
-    persistLinkChanges(item, text, href);
-    closeLinkEditor();
-    import('./classic.js').then(({ renderBuilderInputs }) => {
-        renderBuilderInputs();
-    });
-}
-
-export function openImageResizer(imgEl, item) {
-    closeActiveInlineEditors();
-    const resizer = document.createElement('div');
-    resizer.className = 'image-resizer-overlay';
-    resizer.style.position = 'fixed';
-    resizer.style.left = '50%';
-    resizer.style.transform = 'translateX(-50%)';
-    resizer.style.bottom = '20px';
-    resizer.style.zIndex = 60;
-    resizer.style.background = 'white';
-    resizer.style.padding = '8px 12px';
-    resizer.style.borderRadius = '8px';
-    resizer.style.boxShadow = '0 6px 18px rgba(0,0,0,0.12)';
-
-    const input = document.createElement('input');
-    input.type = 'range';
-    input.min = 100;
-    input.max = 1200;
-    input.step = 1;
-    input.value = item.size || 350;
-    input.style.width = '300px';
-    const label = document.createElement('span');
-    label.textContent = `${input.value}px`;
-    label.style.marginLeft = '10px';
-
-    input.addEventListener('input', () => {
-        const sizeValue = input.value;
-        item.size = Number(sizeValue);
-        imgEl.style.maxWidth = `${sizeValue}px`;
-        label.textContent = `${sizeValue}px`;
-        // update builder input display if visible
-        const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`);
-        if (itemEl) {
-            const display = itemEl.querySelector('[data-role="size-display"]');
-            const slider = itemEl.querySelector('[data-key="size"]');
-            if (display) display.textContent = `${sizeValue}px`;
-            if (slider) slider.value = sizeValue;
-        }
-    });
-
-    // URL and alt inputs
-    const urlLabel = document.createElement('label');
-    urlLabel.textContent = 'Image URL';
-    urlLabel.style.display = 'block';
-    urlLabel.style.marginTop = '8px';
-    const urlInput = document.createElement('input');
-    urlInput.type = 'url';
-    urlInput.value = item.src || '';
-    urlInput.placeholder = 'https://...';
-    urlInput.style.width = '420px';
-    urlInput.style.display = 'block';
-    urlInput.style.marginTop = '4px';
-
-    const altLabel = document.createElement('label');
-    altLabel.textContent = 'Alt text';
-    altLabel.style.display = 'block';
-    altLabel.style.marginTop = '6px';
-    const altInput = document.createElement('input');
-    altInput.type = 'text';
-    altInput.value = item.alt || '';
-    altInput.style.width = '420px';
-    altInput.style.display = 'block';
-    altInput.style.marginTop = '4px';
-
-    const applyBtn = document.createElement('button');
-    applyBtn.textContent = 'Apply';
-    applyBtn.className = 'ml-3 px-3 py-1 bg-blue-600 text-white rounded';
-    applyBtn.addEventListener('click', () => {
-        const newUrl = urlInput.value.trim();
-        const newAlt = altInput.value.trim();
-        if (newUrl) {
-            item.src = newUrl;
-            imgEl.src = newUrl;
-        }
-        item.alt = newAlt;
-        imgEl.alt = newAlt;
-        // update builder inputs if visible
-        const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`);
-        if (itemEl) {
-            const srcInput = itemEl.querySelector('[data-key="src"]');
-            const altInputEl = itemEl.querySelector('[data-key="alt"]');
-            if (srcInput) srcInput.value = item.src;
-            if (altInputEl) altInputEl.value = item.alt;
-        }
-    });
-
-    const closeBtn = document.createElement('button');
-    closeBtn.textContent = 'Done';
-    closeBtn.className = 'ml-3 px-3 py-1 bg-gray-100 rounded';
-    closeBtn.addEventListener('click', closeImageResizer);
-
-    resizer.appendChild(input);
-    resizer.appendChild(label);
-    resizer.appendChild(urlLabel);
-    resizer.appendChild(urlInput);
-    resizer.appendChild(altLabel);
-    resizer.appendChild(altInput);
-    resizer.appendChild(applyBtn);
-    resizer.appendChild(closeBtn);
-    document.body.appendChild(resizer);
-    currentResizer = resizer;
-}
-
-export function closeImageResizer() {
-    if (currentResizer) {
-        currentResizer.remove();
-        currentResizer = null;
+    item.alt = newAlt
+    imgEl.alt = newAlt
+    // update builder inputs if visible
+    const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`)
+    if (itemEl) {
+      const srcInput = itemEl.querySelector('[data-key="src"]')
+      const altInputEl = itemEl.querySelector('[data-key="alt"]')
+      if (srcInput) srcInput.value = item.src
+      if (altInputEl) altInputEl.value = item.alt
     }
+  })
+
+  const closeBtn = document.createElement('button')
+  closeBtn.textContent = 'Done'
+  closeBtn.className = 'ml-3 px-3 py-1 bg-gray-100 rounded'
+  closeBtn.addEventListener('click', closeImageResizer)
+
+  resizer.appendChild(input)
+  resizer.appendChild(label)
+  resizer.appendChild(urlLabel)
+  resizer.appendChild(urlInput)
+  resizer.appendChild(altLabel)
+  resizer.appendChild(altInput)
+  resizer.appendChild(applyBtn)
+  resizer.appendChild(closeBtn)
+  document.body.appendChild(resizer)
+  currentResizer = resizer
 }
 
-export function openLinkEditor(item) {
-    closeActiveInlineEditors();
-    const editor = document.createElement('div');
-    editor.className = 'inline-link-editor-overlay';
-    editor.style.position = 'fixed';
-    editor.style.left = '50%';
-    editor.style.transform = 'translateX(-50%)';
-    editor.style.bottom = '20px';
-    editor.style.zIndex = 61;
-    editor.style.background = 'white';
-    editor.style.padding = '12px';
-    editor.style.borderRadius = '8px';
-    editor.style.boxShadow = '0 6px 18px rgba(0,0,0,0.12)';
-    editor.style.width = 'min(560px, calc(100vw - 32px))';
-
-    const title = document.createElement('p');
-    title.textContent = 'Edit link';
-    title.style.fontWeight = '700';
-    title.style.marginBottom = '8px';
-    title.style.fontSize = '14px';
-
-    const textLabel = document.createElement('label');
-    textLabel.textContent = 'Link text';
-    textLabel.style.display = 'block';
-    textLabel.style.fontSize = '12px';
-    textLabel.style.color = '#374151';
-
-    const textInput = document.createElement('input');
-    textInput.type = 'text';
-    textInput.value = item.content || '';
-    textInput.placeholder = 'Link text';
-    textInput.style.width = '100%';
-    textInput.style.marginTop = '4px';
-    textInput.style.marginBottom = '8px';
-
-    const hrefLabel = document.createElement('label');
-    hrefLabel.textContent = 'URL';
-    hrefLabel.style.display = 'block';
-    hrefLabel.style.fontSize = '12px';
-    hrefLabel.style.color = '#374151';
-
-    const hrefInput = document.createElement('input');
-    const hrefInputId = `link-editor-href-${++linkEditorInputIdCounter}`;
-    hrefInput.type = 'url';
-    hrefInput.id = hrefInputId;
-    hrefInput.value = item.href || '';
-    hrefInput.placeholder = 'https://example.com';
-    hrefInput.style.width = '100%';
-    hrefInput.style.marginTop = '4px';
-    hrefInput.style.marginBottom = '10px';
-    hrefLabel.htmlFor = hrefInputId;
-
-    const actions = document.createElement('div');
-    actions.style.display = 'flex';
-    actions.style.justifyContent = 'flex-end';
-    actions.style.gap = '8px';
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.textContent = 'Cancel';
-    cancelBtn.className = 'px-3 py-1 bg-gray-100 rounded';
-    cancelBtn.addEventListener('click', closeLinkEditor);
-
-    const saveBtn = document.createElement('button');
-    saveBtn.textContent = 'Save';
-    saveBtn.className = 'px-3 py-1 bg-blue-600 text-white rounded';
-    saveBtn.addEventListener('click', () => {
-        saveLinkAndRerender(item, textInput.value, hrefInput.value);
-    });
-
-    actions.appendChild(cancelBtn);
-    actions.appendChild(saveBtn);
-    editor.appendChild(title);
-    editor.appendChild(textLabel);
-    editor.appendChild(textInput);
-    editor.appendChild(hrefLabel);
-    editor.appendChild(hrefInput);
-    editor.appendChild(actions);
-
-    const handleKeyboardSave = (event) => {
-        if (event.key === 'Enter') {
-            event.preventDefault();
-            saveLinkAndRerender(item, textInput.value, hrefInput.value);
-        }
-    };
-    textInput.addEventListener('keydown', handleKeyboardSave);
-    hrefInput.addEventListener('keydown', handleKeyboardSave);
-
-    document.body.appendChild(editor);
-    currentLinkEditor = editor;
-    textInput.focus();
+export function closeImageResizer () {
+  if (currentResizer) {
+    currentResizer.remove()
+    currentResizer = null
+  }
 }
 
-export function closeLinkEditor() {
-    if (currentLinkEditor) {
-        currentLinkEditor.remove();
-        currentLinkEditor = null;
+export function openLinkEditor (item) {
+  closeActiveInlineEditors()
+  const editor = document.createElement('div')
+  editor.className = 'inline-link-editor-overlay'
+  editor.style.position = 'fixed'
+  editor.style.left = '50%'
+  editor.style.transform = 'translateX(-50%)'
+  editor.style.bottom = '20px'
+  editor.style.zIndex = 61
+  editor.style.background = 'white'
+  editor.style.padding = '12px'
+  editor.style.borderRadius = '8px'
+  editor.style.boxShadow = '0 6px 18px rgba(0,0,0,0.12)'
+  editor.style.width = 'min(560px, calc(100vw - 32px))'
+
+  const title = document.createElement('p')
+  title.textContent = 'Edit link'
+  title.style.fontWeight = '700'
+  title.style.marginBottom = '8px'
+  title.style.fontSize = '14px'
+
+  const textLabel = document.createElement('label')
+  textLabel.textContent = 'Link text'
+  textLabel.style.display = 'block'
+  textLabel.style.fontSize = '12px'
+  textLabel.style.color = '#374151'
+
+  const textInput = document.createElement('input')
+  textInput.type = 'text'
+  textInput.value = item.content || ''
+  textInput.placeholder = 'Link text'
+  textInput.style.width = '100%'
+  textInput.style.marginTop = '4px'
+  textInput.style.marginBottom = '8px'
+
+  const hrefLabel = document.createElement('label')
+  hrefLabel.textContent = 'URL'
+  hrefLabel.style.display = 'block'
+  hrefLabel.style.fontSize = '12px'
+  hrefLabel.style.color = '#374151'
+
+  const hrefInput = document.createElement('input')
+  const hrefInputId = `link-editor-href-${++linkEditorInputIdCounter}`
+  hrefInput.type = 'url'
+  hrefInput.id = hrefInputId
+  hrefInput.value = item.href || ''
+  hrefInput.placeholder = 'https://example.com'
+  hrefInput.style.width = '100%'
+  hrefInput.style.marginTop = '4px'
+  hrefInput.style.marginBottom = '10px'
+  hrefLabel.htmlFor = hrefInputId
+
+  const actions = document.createElement('div')
+  actions.style.display = 'flex'
+  actions.style.justifyContent = 'flex-end'
+  actions.style.gap = '8px'
+
+  const cancelBtn = document.createElement('button')
+  cancelBtn.textContent = 'Cancel'
+  cancelBtn.className = 'px-3 py-1 bg-gray-100 rounded'
+  cancelBtn.addEventListener('click', closeLinkEditor)
+
+  const saveBtn = document.createElement('button')
+  saveBtn.textContent = 'Save'
+  saveBtn.className = 'px-3 py-1 bg-blue-600 text-white rounded'
+  saveBtn.addEventListener('click', () => {
+    saveLinkAndRerender(item, textInput.value, hrefInput.value)
+  })
+
+  actions.appendChild(cancelBtn)
+  actions.appendChild(saveBtn)
+  editor.appendChild(title)
+  editor.appendChild(textLabel)
+  editor.appendChild(textInput)
+  editor.appendChild(hrefLabel)
+  editor.appendChild(hrefInput)
+  editor.appendChild(actions)
+
+  const handleKeyboardSave = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      saveLinkAndRerender(item, textInput.value, hrefInput.value)
     }
+  }
+  textInput.addEventListener('keydown', handleKeyboardSave)
+  hrefInput.addEventListener('keydown', handleKeyboardSave)
+
+  document.body.appendChild(editor)
+  currentLinkEditor = editor
+  textInput.focus()
+}
+
+export function closeLinkEditor () {
+  if (currentLinkEditor) {
+    currentLinkEditor.remove()
+    currentLinkEditor = null
+  }
 }
 
 // --- Drag/Drop Reorder Helper ---
 
-function reorderItems(dragId, targetId) {
-    const dragIndex = recipeData.items.findIndex(i => String(i.id) === String(dragId));
-    if (dragIndex === -1) return;
-    const [dragItem] = recipeData.items.splice(dragIndex, 1);
-    // find current index of target (after removal)
-    const newTargetIndex = recipeData.items.findIndex(i => String(i.id) === String(targetId));
-    if (newTargetIndex === -1) {
-        recipeData.items.push(dragItem);
-    } else {
-        recipeData.items.splice(newTargetIndex, 0, dragItem);
-    }
+function reorderItems (dragId, targetId) {
+  const dragIndex = recipeData.items.findIndex(
+    (i) => String(i.id) === String(dragId)
+  )
+  if (dragIndex === -1) return
+  const [dragItem] = recipeData.items.splice(dragIndex, 1)
+  // find current index of target (after removal)
+  const newTargetIndex = recipeData.items.findIndex(
+    (i) => String(i.id) === String(targetId)
+  )
+  if (newTargetIndex === -1) {
+    recipeData.items.push(dragItem)
+  } else {
+    recipeData.items.splice(newTargetIndex, 0, dragItem)
+  }
 }
 
 // --- Inline Input / Blur Handlers ---
 
-export function handleInlineInput(e) {
-    const el = e.target;
-    const key = el.dataset.key;
-    const id = el.dataset.id;
+export function handleInlineInput (e) {
+  const el = e.target
+  const key = el.dataset.key
+  const id = el.dataset.id
 
-    if (!key) return;
+  if (!key) return
 
-    if (key === 'title' || key === 'description') {
-        const { text, caret } = getTextAndCaret(el);
-        if (key === 'title') recipeData.title = text;
-        else recipeData.description = text;
-        // keep the builder inputs in sync
-        dom.titleInput.value = recipeData.title;
-        dom.descInput.value = recipeData.description;
-        // also update preview title/desc if needed
-        dom.titlePreview.innerHTML = renderIconCodes(recipeData.title);
-        dom.descPreview.innerHTML = renderIconCodes(recipeData.description);
-        // update the editable node's HTML to show icons and restore caret
-        const newHtml = renderIconCodes(text);
-        el.innerHTML = newHtml;
-        setCaretPosition(el, caret);
-        return;
-    }
+  if (key === 'title' || key === 'description') {
+    const { text, caret } = getTextAndCaret(el)
+    if (key === 'title') recipeData.title = text
+    else recipeData.description = text
+    // keep the builder inputs in sync
+    dom.titleInput.value = recipeData.title
+    dom.descInput.value = recipeData.description
+    // also update preview title/desc if needed
+    dom.titlePreview.innerHTML = renderIconCodes(recipeData.title)
+    dom.descPreview.innerHTML = renderIconCodes(recipeData.description)
+    // update the editable node's HTML to show icons and restore caret
+    const newHtml = renderIconCodes(text)
+    el.innerHTML = newHtml
+    setCaretPosition(el, caret)
+    return
+  }
 
-    // content for items
-    const item = recipeData.items.find(i => String(i.id) === String(id));
-    if (!item) return;
-    const { text: codeText, caret: newCaret } = getTextAndCaret(el);
-    item.content = codeText || '';
-    const newHtml = renderIconCodes(item.content);
-    el.innerHTML = newHtml;
-    setCaretPosition(el, newCaret);
+  // content for items
+  const item = recipeData.items.find((i) => String(i.id) === String(id))
+  if (!item) return
+  const { text: codeText, caret: newCaret } = getTextAndCaret(el)
+  item.content = codeText || ''
+  const newHtml = renderIconCodes(item.content)
+  el.innerHTML = newHtml
+  setCaretPosition(el, newCaret)
 
-    // reflect changes into builder inputs if present
-    const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`);
-    if (itemEl) {
-        const input = itemEl.querySelector('[data-key="content"]');
-        if (input) input.value = item.content;
-    }
+  // reflect changes into builder inputs if present
+  const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`)
+  if (itemEl) {
+    const input = itemEl.querySelector('[data-key="content"]')
+    if (input) input.value = item.content
+  }
 }
 
-export function handleInlineBlur(e) {
-    const el = e.target;
-    if (!el) return;
-    const { text } = getTextAndCaret(el);
-    const key = el.dataset.key;
-    const id = el.dataset.id;
-    if (key === 'title') {
-        recipeData.title = text;
-        dom.titleInput.value = recipeData.title;
-        dom.titlePreview.innerHTML = renderIconCodes(recipeData.title);
-    } else if (key === 'description') {
-        recipeData.description = text;
-        dom.descInput.value = recipeData.description;
-        dom.descPreview.innerHTML = renderIconCodes(recipeData.description);
-    } else if (id) {
-        const item = recipeData.items.find(i => String(i.id) === String(id));
-        if (item) {
-            item.content = text;
-            const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`);
-            if (itemEl) {
-                const input = itemEl.querySelector('[data-key="content"]');
-                if (input) input.value = item.content;
-            }
-        }
+export function handleInlineBlur (e) {
+  const el = e.target
+  if (!el) return
+  const { text } = getTextAndCaret(el)
+  const key = el.dataset.key
+  const id = el.dataset.id
+  if (key === 'title') {
+    recipeData.title = text
+    dom.titleInput.value = recipeData.title
+    dom.titlePreview.innerHTML = renderIconCodes(recipeData.title)
+  } else if (key === 'description') {
+    recipeData.description = text
+    dom.descInput.value = recipeData.description
+    dom.descPreview.innerHTML = renderIconCodes(recipeData.description)
+  } else if (id) {
+    const item = recipeData.items.find((i) => String(i.id) === String(id))
+    if (item) {
+      item.content = text
+      const itemEl = dom.contentInputs.querySelector(`[data-id="${item.id}"]`)
+      if (itemEl) {
+        const input = itemEl.querySelector('[data-key="content"]')
+        if (input) input.value = item.content
+      }
     }
+  }
 
-    const newHtml = renderIconCodes(text || '');
-    el.innerHTML = newHtml;
+  const newHtml = renderIconCodes(text || '')
+  el.innerHTML = newHtml
 }
 
 // --- Inline Preview Renderer ---
 
-export function renderInlinePreview() {
-    if (!dom.inlinePreview) return;
-    if (!recipeData.settings || recipeData.settings.editorMode !== 'inline') return;
-    closeLinkEditor();
-    dom.inlinePreview.innerHTML = '';
+export function renderInlinePreview () {
+  if (!dom.inlinePreview) return
+  if (!recipeData.settings || recipeData.settings.editorMode !== 'inline') {
+    return
+  }
+  closeLinkEditor()
+  dom.inlinePreview.innerHTML = ''
 
-    const fontStyle = recipeData.settings.fontStyle || 'display';
+  const fontStyle = recipeData.settings.fontStyle || 'display'
 
-    // Title (editable)
-    const h1 = document.createElement('h1');
-    h1.className = `text-4xl font-bold mb-4 font-style-${fontStyle}`;
-    h1.contentEditable = true;
-    h1.dataset.key = 'title';
-    h1.innerHTML = renderIconCodes(recipeData.title);
-    // Outline for empty title so users notice it's editable
-    if (!recipeData.title || recipeData.title.trim() === '') {
-        h1.classList.add('new-text-outline');
-        const removeOutline = () => { h1.classList.remove('new-text-outline'); h1.removeEventListener('input', removeOutline); };
-        h1.addEventListener('input', removeOutline);
-        setTimeout(() => h1.focus(), 20);
+  // Title (editable)
+  const h1 = document.createElement('h1')
+  h1.className = `text-4xl font-bold mb-4 font-style-${fontStyle}`
+  h1.contentEditable = true
+  h1.dataset.key = 'title'
+  h1.innerHTML = renderIconCodes(recipeData.title)
+  // Outline for empty title so users notice it's editable
+  if (!recipeData.title || recipeData.title.trim() === '') {
+    h1.classList.add('new-text-outline')
+    const removeOutline = () => {
+      h1.classList.remove('new-text-outline')
+      h1.removeEventListener('input', removeOutline)
     }
-    dom.inlinePreview.appendChild(h1);
+    h1.addEventListener('input', removeOutline)
+    setTimeout(() => h1.focus(), 20)
+  }
+  dom.inlinePreview.appendChild(h1)
 
-    // Description (editable)
-    const descriptionParagraph = document.createElement('p');
-    descriptionParagraph.className = 'text-gray-600 italic mb-4';
-    descriptionParagraph.contentEditable = true;
-    descriptionParagraph.dataset.key = 'description';
-    descriptionParagraph.innerHTML = renderIconCodes(recipeData.description);
-    // Outline for empty description
-    if (!recipeData.description || recipeData.description.trim() === '') {
-        descriptionParagraph.classList.add('new-text-outline');
-        const removeOutlineDesc = () => {
-            descriptionParagraph.classList.remove('new-text-outline');
-            descriptionParagraph.removeEventListener('input', removeOutlineDesc);
-        };
-        descriptionParagraph.addEventListener('input', removeOutlineDesc);
+  // Description (editable)
+  const descriptionParagraph = document.createElement('p')
+  descriptionParagraph.className = 'text-gray-600 italic mb-4'
+  descriptionParagraph.contentEditable = true
+  descriptionParagraph.dataset.key = 'description'
+  descriptionParagraph.innerHTML = renderIconCodes(recipeData.description)
+  // Outline for empty description
+  if (!recipeData.description || recipeData.description.trim() === '') {
+    descriptionParagraph.classList.add('new-text-outline')
+    const removeOutlineDesc = () => {
+      descriptionParagraph.classList.remove('new-text-outline')
+      descriptionParagraph.removeEventListener('input', removeOutlineDesc)
     }
-    dom.inlinePreview.appendChild(descriptionParagraph);
+    descriptionParagraph.addEventListener('input', removeOutlineDesc)
+  }
+  dom.inlinePreview.appendChild(descriptionParagraph)
 
-    // Content (wrap in draggable inline-item wrappers; support dblclick removal and drag/drop reordering)
-    let currentList = null;
-    let currentListType = null;
-    let stepCounter = 0;
+  // Content (wrap in draggable inline-item wrappers; support dblclick removal and drag/drop reordering)
+  let currentList = null
+  let currentListType = null
+  let stepCounter = 0
 
-    const rerenderAllEditors = () => {
-        import('./classic.js').then(({ renderBuilderInputs }) => {
-            renderBuilderInputs();
-            renderInlinePreview();
-        });
-    };
+  const rerenderAllEditors = () => {
+    import('./classic.js').then(({ renderBuilderInputs }) => {
+      renderBuilderInputs()
+      renderInlinePreview()
+    })
+  }
 
-    const attachInlineItemInteractions = (node, itemId) => {
-        node.addEventListener('dblclick', async (ev) => {
-            ev.stopPropagation();
-            if (await openInlineDeleteConfirm('Remove this item?')) {
-                recipeData.items = recipeData.items.filter(i => String(i.id) !== String(itemId));
-                rerenderAllEditors();
-            }
-        });
+  const attachInlineItemInteractions = (node, itemId) => {
+    node.addEventListener('dblclick', async (ev) => {
+      ev.stopPropagation()
+      if (await openInlineDeleteConfirm('Remove this item?')) {
+        recipeData.items = recipeData.items.filter(
+          (i) => String(i.id) !== String(itemId)
+        )
+        rerenderAllEditors()
+      }
+    })
 
-        node.addEventListener('dragstart', (ev) => {
-            ev.dataTransfer.setData('text/plain', String(itemId));
-            node.classList.add('dragging');
-        });
-        node.addEventListener('dragend', () => {
-            node.classList.remove('dragging');
-            dom.inlinePreview.querySelectorAll('.inline-item.drop-target').forEach(n => n.classList.remove('drop-target'));
-        });
-        node.addEventListener('dragover', (ev) => { ev.preventDefault(); node.classList.add('drop-target'); });
-        node.addEventListener('dragleave', () => { node.classList.remove('drop-target'); });
-        node.addEventListener('drop', (ev) => {
-            ev.preventDefault();
-            const dragId = ev.dataTransfer.getData('text/plain');
-            const targetId = node.dataset.id;
-            if (dragId && targetId && dragId !== targetId) {
-                reorderItems(dragId, targetId);
-                rerenderAllEditors();
-            }
-        });
-    };
+    node.addEventListener('dragstart', (ev) => {
+      ev.dataTransfer.setData('text/plain', String(itemId))
+      node.classList.add('dragging')
+    })
+    node.addEventListener('dragend', () => {
+      node.classList.remove('dragging')
+      dom.inlinePreview
+        .querySelectorAll('.inline-item.drop-target')
+        .forEach((n) => n.classList.remove('drop-target'))
+    })
+    node.addEventListener('dragover', (ev) => {
+      ev.preventDefault()
+      node.classList.add('drop-target')
+    })
+    node.addEventListener('dragleave', () => {
+      node.classList.remove('drop-target')
+    })
+    node.addEventListener('drop', (ev) => {
+      ev.preventDefault()
+      const dragId = ev.dataTransfer.getData('text/plain')
+      const targetId = node.dataset.id
+      if (dragId && targetId && dragId !== targetId) {
+        reorderItems(dragId, targetId)
+        rerenderAllEditors()
+      }
+    })
+  }
 
-    const ensureListContainer = (type) => {
-        if (currentList && currentListType === type) return currentList;
+  const ensureListContainer = (type) => {
+    if (currentList && currentListType === type) return currentList
 
-        currentList = document.createElement(type === 'step' ? 'ol' : 'ul');
-        currentList.className = type === 'step' ? 'inline-step-list' : 'inline-bullet-list';
-        currentListType = type;
-        dom.inlinePreview.appendChild(currentList);
-        return currentList;
-    };
+    currentList = document.createElement(type === 'step' ? 'ol' : 'ul')
+    currentList.className =
+      type === 'step' ? 'inline-step-list' : 'inline-bullet-list'
+    currentListType = type
+    dom.inlinePreview.appendChild(currentList)
+    return currentList
+  }
 
-    recipeData.items.forEach(item => {
-        const contentWithIcons = renderIconCodes(item.content || '');
+  recipeData.items.forEach((item) => {
+    const contentWithIcons = renderIconCodes(item.content || '')
 
-        if (item.type === 'step') {
-            if (currentListType !== 'step') stepCounter = 0;
-            stepCounter += 1;
+    if (item.type === 'step') {
+      if (currentListType !== 'step') stepCounter = 0
+      stepCounter += 1
 
-            const list = ensureListContainer('step');
-            const li = document.createElement('li');
-            li.className = 'inline-item inline-list-item';
-            li.dataset.id = item.id;
-            li.draggable = true;
+      const list = ensureListContainer('step')
+      const li = document.createElement('li')
+      li.className = 'inline-item inline-list-item'
+      li.dataset.id = item.id
+      li.draggable = true
 
-            const { badge, contentSpan } = stepHandler.renderInlineElement(item, fontStyle, contentWithIcons, stepCounter);
-            li.appendChild(badge);
-            li.appendChild(contentSpan);
-            list.appendChild(li);
-            attachInlineItemInteractions(li, item.id);
-            return;
+      const { badge, contentSpan } = stepHandler.renderInlineElement(
+        item,
+        fontStyle,
+        contentWithIcons,
+        stepCounter
+      )
+      li.appendChild(badge)
+      li.appendChild(contentSpan)
+      list.appendChild(li)
+      attachInlineItemInteractions(li, item.id)
+      return
+    }
+
+    if (item.type === 'bullet') {
+      const list = ensureListContainer('bullet')
+      const li = document.createElement('li')
+      li.className = 'inline-item inline-list-item'
+      li.dataset.id = item.id
+      li.draggable = true
+
+      const { badge, contentSpan } = renderInlineBulletElement(
+        item,
+        fontStyle,
+        contentWithIcons
+      )
+      li.appendChild(badge)
+      li.appendChild(contentSpan)
+      list.appendChild(li)
+      attachInlineItemInteractions(li, item.id)
+      return
+    }
+
+    currentList = null
+    currentListType = null
+    stepCounter = 0
+
+    {
+      let renderedElement = null
+
+      switch (item.type) {
+        case 'heading':
+          renderedElement = headingHandler.renderInlineElement(
+            item,
+            fontStyle,
+            contentWithIcons
+          )
+          break
+        case 'text':
+          renderedElement = textHandler.renderInlineElement(
+            item,
+            fontStyle,
+            contentWithIcons
+          )
+          break
+        case 'image':
+          renderedElement = imageHandler.renderInlineElement(
+            item,
+            fontStyle,
+            contentWithIcons
+          )
+          renderedElement.addEventListener('click', (e) => {
+            e.stopPropagation()
+            openImageResizer(renderedElement, item)
+          })
+          break
+        case 'bubble':
+          renderedElement = bubbleHandler.renderInlineElement(
+            item,
+            fontStyle,
+            contentWithIcons
+          )
+          break
+        case 'link': {
+          renderedElement = renderInlineLinkElement(
+            item,
+            fontStyle,
+            contentWithIcons
+          )
+          const anchorEl = renderedElement.querySelector('a')
+          if (anchorEl) {
+            anchorEl.classList.add('inline-edit-link')
+            // Disable native dragging on the anchor so the wrapper remains the drag source.
+            anchorEl.draggable = false
+            anchorEl.addEventListener('dragstart', (e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            })
+            anchorEl.addEventListener('click', (e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              openLinkEditor(item)
+            })
+          }
+          break
         }
+        default:
+          break
+      }
 
-        if (item.type === 'bullet') {
-            const list = ensureListContainer('bullet');
-            const li = document.createElement('li');
-            li.className = 'inline-item inline-list-item';
-            li.dataset.id = item.id;
-            li.draggable = true;
+      if (!renderedElement) return
 
-            const { badge, contentSpan } = renderInlineBulletElement(item, fontStyle, contentWithIcons);
-            li.appendChild(badge);
-            li.appendChild(contentSpan);
-            list.appendChild(li);
-            attachInlineItemInteractions(li, item.id);
-            return;
+      const wrapper = document.createElement('div')
+      wrapper.className = 'inline-item'
+      wrapper.dataset.id = item.id
+      wrapper.draggable = true
+      wrapper.appendChild(renderedElement)
+
+      // mark new text with outline to make it visible
+      if (
+        (item.type === 'text' || item.type === 'heading') &&
+        (!item.content || item.content.trim() === '')
+      ) {
+        renderedElement.classList.add('new-text-outline')
+        const onFirstInput = () => {
+          renderedElement.classList.remove('new-text-outline')
+          renderedElement.removeEventListener('input', onFirstInput)
         }
+        renderedElement.addEventListener('input', onFirstInput)
+        setTimeout(() => renderedElement.focus(), 20)
+      }
+      dom.inlinePreview.appendChild(wrapper)
 
-        currentList = null;
-        currentListType = null;
-        stepCounter = 0;
+      attachInlineItemInteractions(wrapper, item.id)
+    }
+  })
 
-        {
-            let renderedElement = null;
+  // Attach input listeners for editable regions
+  dom.inlinePreview
+    .querySelectorAll('[contenteditable=true]')
+    .forEach((node) => {
+      node.addEventListener('input', handleInlineInput)
+      node.addEventListener('blur', handleInlineBlur)
+    })
 
-            switch (item.type) {
-                case 'heading':
-                    renderedElement = headingHandler.renderInlineElement(item, fontStyle, contentWithIcons);
-                    break;
-                case 'text':
-                    renderedElement = textHandler.renderInlineElement(item, fontStyle, contentWithIcons);
-                    break;
-                case 'image':
-                    renderedElement = imageHandler.renderInlineElement(item, fontStyle, contentWithIcons);
-                    renderedElement.addEventListener('click', (e) => {
-                        e.stopPropagation();
-                        openImageResizer(renderedElement, item);
-                    });
-                    break;
-                case 'bubble':
-                    renderedElement = bubbleHandler.renderInlineElement(item, fontStyle, contentWithIcons);
-                    break;
-                case 'link': {
-                    renderedElement = renderInlineLinkElement(item, fontStyle, contentWithIcons);
-                    const anchorEl = renderedElement.querySelector('a');
-                    if (anchorEl) {
-                        anchorEl.classList.add('inline-edit-link');
-                        // Disable native dragging on the anchor so the wrapper remains the drag source.
-                        anchorEl.draggable = false;
-                        anchorEl.addEventListener('dragstart', (e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                        });
-                        anchorEl.addEventListener('click', (e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            openLinkEditor(item);
-                        });
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-
-            if (!renderedElement) return;
-
-            const wrapper = document.createElement('div');
-            wrapper.className = 'inline-item';
-            wrapper.dataset.id = item.id;
-            wrapper.draggable = true;
-            wrapper.appendChild(renderedElement);
-
-            // mark new text with outline to make it visible
-            if ((item.type === 'text' || item.type === 'heading') && (!item.content || item.content.trim() === '')) {
-                renderedElement.classList.add('new-text-outline');
-                const onFirstInput = () => {
-                    renderedElement.classList.remove('new-text-outline');
-                    renderedElement.removeEventListener('input', onFirstInput);
-                };
-                renderedElement.addEventListener('input', onFirstInput);
-                setTimeout(() => renderedElement.focus(), 20);
-            }
-            dom.inlinePreview.appendChild(wrapper);
-
-            attachInlineItemInteractions(wrapper, item.id);
-        }
-    });
-
-    // Attach input listeners for editable regions
-    dom.inlinePreview.querySelectorAll('[contenteditable=true]').forEach(node => {
-        node.addEventListener('input', handleInlineInput);
-        node.addEventListener('blur', handleInlineBlur);
-    });
-
-    // Container-level drag/drop: drop to append at end
-    dom.inlinePreview.ondragover = function(e) { e.preventDefault(); };
-    dom.inlinePreview.ondrop = function(e) {
-        e.preventDefault();
-        const dragId = e.dataTransfer.getData('text/plain');
-        if (!dragId) return;
-        const idx = recipeData.items.findIndex(i => String(i.id) === String(dragId));
-        if (idx === -1) return;
-        const [draggedItem] = recipeData.items.splice(idx, 1);
-        recipeData.items.push(draggedItem);
-        import('./classic.js').then(({ renderBuilderInputs }) => {
-            renderBuilderInputs();
-            renderInlinePreview();
-        });
-    };
+  // Container-level drag/drop: drop to append at end
+  dom.inlinePreview.ondragover = function (e) {
+    e.preventDefault()
+  }
+  dom.inlinePreview.ondrop = function (e) {
+    e.preventDefault()
+    const dragId = e.dataTransfer.getData('text/plain')
+    if (!dragId) return
+    const idx = recipeData.items.findIndex(
+      (i) => String(i.id) === String(dragId)
+    )
+    if (idx === -1) return
+    const [draggedItem] = recipeData.items.splice(idx, 1)
+    recipeData.items.push(draggedItem)
+    import('./classic.js').then(({ renderBuilderInputs }) => {
+      renderBuilderInputs()
+      renderInlinePreview()
+    })
+  }
 }

--- a/js/dom.js
+++ b/js/dom.js
@@ -1,101 +1,107 @@
 // --- DOM REFERENCES ---
 // Populated by initDom() after HTML partials are loaded.
 export const dom = {
-    builderPanel: null,
-    recipePanel: null,
-    titleInput: null,
-    descInput: null,
-    titlePreview: null,
-    descPreview: null,
-    contentInputs: null,
-    contentPreview: null,
-    addTextBtn: null,
-    addImageBtn: null,
-    addToastBtn: null,
-    previewBtn: null,
-    editBtn: null,
-    printBtn: null,
-    // Toast Modal
-    toastModal: null,
-    toastModalOverlay: null,
-    closeModalBtn: null,
-    toastTypeTipBtn: null,
-    toastTypeWarningBtn: null,
-    toastTypeNoteBtn: null,
-    // Text Modal
-    textModal: null,
-    textModalOverlay: null,
-    closeTextModalBtn: null,
-    textTypeHeadingBtn: null,
-    textTypeStepBtn: null,
-    textTypeBulletBtn: null,
-    textTypeTextBtn: null,
-    textTypeLinkBtn: null,
-    // Icon Key Modal
-    iconKeyBtn: null,
-    iconKeyModal: null,
-    iconKeyModalOverlay: null,
-    closeIconKeyModalBtn: null,
-    iconSearchInput: null,
-    iconListContainer: null,
-    // Settings Modal
-    settingsBtn: null,
-    settingsModal: null,
-    settingsModalOverlay: null,
-    closeSettingsModalBtn: null,
-    globalFontStyleSelect: null,
-    editorModeSelect: null,
-    // Inline editor
-    floatingAddBtn: null,
-    inlinePreview: null,
-};
+  builderPanel: null,
+  recipePanel: null,
+  titleInput: null,
+  descInput: null,
+  titlePreview: null,
+  descPreview: null,
+  contentInputs: null,
+  contentPreview: null,
+  addTextBtn: null,
+  addImageBtn: null,
+  addToastBtn: null,
+  previewBtn: null,
+  editBtn: null,
+  printBtn: null,
+  // Toast Modal
+  toastModal: null,
+  toastModalOverlay: null,
+  closeModalBtn: null,
+  toastTypeTipBtn: null,
+  toastTypeWarningBtn: null,
+  toastTypeNoteBtn: null,
+  // Text Modal
+  textModal: null,
+  textModalOverlay: null,
+  closeTextModalBtn: null,
+  textTypeHeadingBtn: null,
+  textTypeStepBtn: null,
+  textTypeBulletBtn: null,
+  textTypeTextBtn: null,
+  textTypeLinkBtn: null,
+  // Icon Key Modal
+  iconKeyBtn: null,
+  iconKeyModal: null,
+  iconKeyModalOverlay: null,
+  closeIconKeyModalBtn: null,
+  iconSearchInput: null,
+  iconListContainer: null,
+  // Settings Modal
+  settingsBtn: null,
+  settingsModal: null,
+  settingsModalOverlay: null,
+  closeSettingsModalBtn: null,
+  globalFontStyleSelect: null,
+  editorModeSelect: null,
+  // Inline editor
+  floatingAddBtn: null,
+  inlinePreview: null
+}
 
-export function initDom() {
-    dom.builderPanel = document.getElementById('builder-panel');
-    dom.recipePanel = document.getElementById('recipe-panel');
-    dom.titleInput = document.getElementById('recipe-title-input');
-    dom.descInput = document.getElementById('recipe-desc-input');
-    dom.titlePreview = document.getElementById('recipe-title-preview');
-    dom.descPreview = document.getElementById('recipe-desc-preview');
-    dom.contentInputs = document.getElementById('content-inputs');
-    dom.contentPreview = document.getElementById('recipe-content-preview');
-    dom.addTextBtn = document.getElementById('add-text-btn');
-    dom.addImageBtn = document.getElementById('add-image-btn');
-    dom.addToastBtn = document.getElementById('add-toast-btn');
-    dom.previewBtn = document.getElementById('preview-btn');
-    dom.editBtn = document.getElementById('edit-btn');
-    dom.printBtn = document.getElementById('print-btn');
-    // Toast Modal
-    dom.toastModal = document.getElementById('toast-modal');
-    dom.toastModalOverlay = document.getElementById('modal-overlay');
-    dom.closeModalBtn = document.getElementById('close-modal-btn');
-    dom.toastTypeTipBtn = document.getElementById('toast-type-tip');
-    dom.toastTypeWarningBtn = document.getElementById('toast-type-warning');
-    dom.toastTypeNoteBtn = document.getElementById('toast-type-note');
-    // Text Modal
-    dom.textModal = document.getElementById('text-modal');
-    dom.textModalOverlay = document.getElementById('modal-overlay-text');
-    dom.closeTextModalBtn = document.getElementById('close-text-modal-btn');
-    dom.textTypeHeadingBtn = document.getElementById('text-type-heading');
-    dom.textTypeStepBtn = document.getElementById('text-type-step');
-    dom.textTypeBulletBtn = document.getElementById('text-type-bullet');
-    dom.textTypeTextBtn = document.getElementById('text-type-text');
-    dom.textTypeLinkBtn = document.getElementById('text-type-link');
-    // Icon Key Modal
-    dom.iconKeyBtn = document.getElementById('icon-key-btn');
-    dom.iconKeyModal = document.getElementById('icon-key-modal');
-    dom.iconKeyModalOverlay = document.getElementById('icon-key-modal-overlay');
-    dom.closeIconKeyModalBtn = document.getElementById('close-icon-key-modal-btn');
-    dom.iconSearchInput = document.getElementById('icon-search-input');
-    dom.iconListContainer = document.getElementById('icon-list-container');
-    // Settings Modal
-    dom.settingsBtn = document.getElementById('settings-btn');
-    dom.settingsModal = document.getElementById('settings-modal');
-    dom.settingsModalOverlay = document.getElementById('settings-modal-overlay');
-    dom.closeSettingsModalBtn = document.getElementById('close-settings-modal-btn');
-    dom.globalFontStyleSelect = document.getElementById('global-font-style-select');
-    dom.editorModeSelect = document.getElementById('editor-mode-select');
-    // Inline editor
-    dom.floatingAddBtn = document.getElementById('floating-add-btn');
-    dom.inlinePreview = document.getElementById('inline-preview');
+export function initDom () {
+  dom.builderPanel = document.getElementById('builder-panel')
+  dom.recipePanel = document.getElementById('recipe-panel')
+  dom.titleInput = document.getElementById('recipe-title-input')
+  dom.descInput = document.getElementById('recipe-desc-input')
+  dom.titlePreview = document.getElementById('recipe-title-preview')
+  dom.descPreview = document.getElementById('recipe-desc-preview')
+  dom.contentInputs = document.getElementById('content-inputs')
+  dom.contentPreview = document.getElementById('recipe-content-preview')
+  dom.addTextBtn = document.getElementById('add-text-btn')
+  dom.addImageBtn = document.getElementById('add-image-btn')
+  dom.addToastBtn = document.getElementById('add-toast-btn')
+  dom.previewBtn = document.getElementById('preview-btn')
+  dom.editBtn = document.getElementById('edit-btn')
+  dom.printBtn = document.getElementById('print-btn')
+  // Toast Modal
+  dom.toastModal = document.getElementById('toast-modal')
+  dom.toastModalOverlay = document.getElementById('modal-overlay')
+  dom.closeModalBtn = document.getElementById('close-modal-btn')
+  dom.toastTypeTipBtn = document.getElementById('toast-type-tip')
+  dom.toastTypeWarningBtn = document.getElementById('toast-type-warning')
+  dom.toastTypeNoteBtn = document.getElementById('toast-type-note')
+  // Text Modal
+  dom.textModal = document.getElementById('text-modal')
+  dom.textModalOverlay = document.getElementById('modal-overlay-text')
+  dom.closeTextModalBtn = document.getElementById('close-text-modal-btn')
+  dom.textTypeHeadingBtn = document.getElementById('text-type-heading')
+  dom.textTypeStepBtn = document.getElementById('text-type-step')
+  dom.textTypeBulletBtn = document.getElementById('text-type-bullet')
+  dom.textTypeTextBtn = document.getElementById('text-type-text')
+  dom.textTypeLinkBtn = document.getElementById('text-type-link')
+  // Icon Key Modal
+  dom.iconKeyBtn = document.getElementById('icon-key-btn')
+  dom.iconKeyModal = document.getElementById('icon-key-modal')
+  dom.iconKeyModalOverlay = document.getElementById('icon-key-modal-overlay')
+  dom.closeIconKeyModalBtn = document.getElementById(
+    'close-icon-key-modal-btn'
+  )
+  dom.iconSearchInput = document.getElementById('icon-search-input')
+  dom.iconListContainer = document.getElementById('icon-list-container')
+  // Settings Modal
+  dom.settingsBtn = document.getElementById('settings-btn')
+  dom.settingsModal = document.getElementById('settings-modal')
+  dom.settingsModalOverlay = document.getElementById('settings-modal-overlay')
+  dom.closeSettingsModalBtn = document.getElementById(
+    'close-settings-modal-btn'
+  )
+  dom.globalFontStyleSelect = document.getElementById(
+    'global-font-style-select'
+  )
+  dom.editorModeSelect = document.getElementById('editor-mode-select')
+  // Inline editor
+  dom.floatingAddBtn = document.getElementById('floating-add-btn')
+  dom.inlinePreview = document.getElementById('inline-preview')
 }

--- a/js/global.js
+++ b/js/global.js
@@ -1,427 +1,484 @@
-import { recipeData } from './state.js';
-import { dom } from './dom.js';
-import { renderIconCodes, copyToClipboard } from './helpers.js';
-import { COMMON_ICONS } from './constants.js';
-import { renderBuilderInputs, renderPreview } from './builders/classic.js';
-import { renderInlinePreview, closeImageResizer, closeLinkEditor } from './builders/inline.js';
+import { recipeData } from './state.js'
+import { dom } from './dom.js'
+import { renderIconCodes, copyToClipboard } from './helpers.js'
+import { COMMON_ICONS } from './constants.js'
+import { renderBuilderInputs, renderPreview } from './builders/classic.js'
+import {
+  renderInlinePreview,
+  closeImageResizer,
+  closeLinkEditor
+} from './builders/inline.js'
 
 // --- ACTIONS ---
-let nextItemId = Date.now();
-let floatingAddMenuCloseHandler = null;
+let nextItemId = Date.now()
+let floatingAddMenuCloseHandler = null
 
-function createItemId() {
-    nextItemId = Math.max(nextItemId + 1, Date.now());
-    return nextItemId;
+function createItemId () {
+  nextItemId = Math.max(nextItemId + 1, Date.now())
+  return nextItemId
 }
 
-export function addItem(type, subtype = null) {
-    const newItem = { id: createItemId() };
-    switch (type) {
-        case 'heading':
-            newItem.type = 'heading';
-            newItem.content = 'New Heading';
-            break;
-        case 'step':
-        case 'bullet':
-        case 'text':
-            newItem.type = type;
-            newItem.content = '';
-            break;
-        case 'image':
-            newItem.type = 'image';
-            newItem.src = '';
-            newItem.alt = '';
-            newItem.size = 350;
-            break;
-        case 'bubble':
-            newItem.type = 'bubble';
-            newItem.subtype = subtype || 'note';
-            newItem.content = '';
-            break;
-        case 'link':
-            newItem.type = 'link';
-            newItem.content = '';
-            newItem.href = '';
-            break;
-        default:
-            break;
-    }
-    recipeData.items.push(newItem);
-    renderBuilderInputs();
+export function addItem (type, subtype = null) {
+  const newItem = { id: createItemId() }
+  switch (type) {
+    case 'heading':
+      newItem.type = 'heading'
+      newItem.content = 'New Heading'
+      break
+    case 'step':
+    case 'bullet':
+    case 'text':
+      newItem.type = type
+      newItem.content = ''
+      break
+    case 'image':
+      newItem.type = 'image'
+      newItem.src = ''
+      newItem.alt = ''
+      newItem.size = 350
+      break
+    case 'bubble':
+      newItem.type = 'bubble'
+      newItem.subtype = subtype || 'note'
+      newItem.content = ''
+      break
+    case 'link':
+      newItem.type = 'link'
+      newItem.content = ''
+      newItem.href = ''
+      break
+    default:
+      break
+  }
+  recipeData.items.push(newItem)
+  renderBuilderInputs()
 
-    const newEl = dom.contentInputs.querySelector(`[data-id="${newItem.id}"]`);
-    if (newEl) {
-        const input = newEl.querySelector('input, textarea');
-        if (input) input.focus();
-    }
+  const newEl = dom.contentInputs.querySelector(`[data-id="${newItem.id}"]`)
+  if (newEl) {
+    const input = newEl.querySelector('input, textarea')
+    if (input) input.focus()
+  }
 }
 
-function moveItem(id, direction) {
-    const index = recipeData.items.findIndex(i => i.id == id);
-    if (direction === 'up' && index > 0) {
-        [recipeData.items[index], recipeData.items[index - 1]] = [recipeData.items[index - 1], recipeData.items[index]];
-    } else if (direction === 'down' && index < recipeData.items.length - 1) {
-        [recipeData.items[index], recipeData.items[index + 1]] = [recipeData.items[index + 1], recipeData.items[index]];
-    }
+function moveItem (id, direction) {
+  const index = recipeData.items.findIndex((i) => i.id == id)
+  if (direction === 'up' && index > 0) {
+    [recipeData.items[index], recipeData.items[index - 1]] = [
+      recipeData.items[index - 1],
+      recipeData.items[index]
+    ]
+  } else if (direction === 'down' && index < recipeData.items.length - 1) {
+    [recipeData.items[index], recipeData.items[index + 1]] = [
+      recipeData.items[index + 1],
+      recipeData.items[index]
+    ]
+  }
 }
 
 // --- MODE HELPERS ---
 
-function isInlineMode() {
-    return recipeData.settings && recipeData.settings.editorMode === 'inline';
+function isInlineMode () {
+  return recipeData.settings && recipeData.settings.editorMode === 'inline'
 }
 
-function closeFloatingAddMenu() {
-    const menu = document.getElementById('floating-add-menu');
-    if (menu) menu.remove();
+function closeFloatingAddMenu () {
+  const menu = document.getElementById('floating-add-menu')
+  if (menu) menu.remove()
 
-    if (floatingAddMenuCloseHandler) {
-        document.removeEventListener('click', floatingAddMenuCloseHandler);
-        floatingAddMenuCloseHandler = null;
-    }
+  if (floatingAddMenuCloseHandler) {
+    document.removeEventListener('click', floatingAddMenuCloseHandler)
+    floatingAddMenuCloseHandler = null
+  }
 }
 
-function toggleOldUIVisibility(hide) {
-    // Hide most of the old controls when inline mode is active,
-    // but keep the badges (icon-key-btn) and settings (settings-btn).
-    const elementsToToggle = [
-        dom.addTextBtn,
-        dom.addImageBtn,
-        dom.addToastBtn,
-        dom.previewBtn,
-        dom.editBtn,
-        dom.printBtn,
-        dom.contentInputs,
-        dom.titleInput,
-        dom.descInput
-    ];
-    // Also hide the labels for the title/description inputs
-    const titleLabel = document.querySelector('label[for="recipe-title-input"]');
-    const descLabel = document.querySelector('label[for="recipe-desc-input"]');
-    if (titleLabel) elementsToToggle.push(titleLabel);
-    if (descLabel) elementsToToggle.push(descLabel);
+function toggleOldUIVisibility (hide) {
+  // Hide most of the old controls when inline mode is active,
+  // but keep the badges (icon-key-btn) and settings (settings-btn).
+  const elementsToToggle = [
+    dom.addTextBtn,
+    dom.addImageBtn,
+    dom.addToastBtn,
+    dom.previewBtn,
+    dom.editBtn,
+    dom.printBtn,
+    dom.contentInputs,
+    dom.titleInput,
+    dom.descInput
+  ]
+  // Also hide the labels for the title/description inputs
+  const titleLabel = document.querySelector('label[for="recipe-title-input"]')
+  const descLabel = document.querySelector('label[for="recipe-desc-input"]')
+  if (titleLabel) elementsToToggle.push(titleLabel)
+  if (descLabel) elementsToToggle.push(descLabel)
 
-    elementsToToggle.forEach(el => {
-        if (!el) return;
-        if (hide) el.classList.add('hidden');
-        else el.classList.remove('hidden');
-    });
+  elementsToToggle.forEach((el) => {
+    if (!el) return
+    if (hide) el.classList.add('hidden')
+    else el.classList.remove('hidden')
+  })
 }
 
-export function enableInlineEditor() {
-    if (dom.inlinePreview) dom.inlinePreview.classList.remove('hidden');
-    if (dom.floatingAddBtn) dom.floatingAddBtn.classList.remove('hidden');
-    toggleOldUIVisibility(true);
+export function enableInlineEditor () {
+  if (dom.inlinePreview) dom.inlinePreview.classList.remove('hidden')
+  if (dom.floatingAddBtn) dom.floatingAddBtn.classList.remove('hidden')
+  toggleOldUIVisibility(true)
+  try {
+    renderInlinePreview()
+  } catch (err) {
+    console.error(
+      'Inline preview render failed while enabling inline mode:',
+      err
+    )
+    // Fall back to classic editor so the user is not left with a broken inline UI.
     try {
-        renderInlinePreview();
-    } catch (err) {
-        console.error('Inline preview render failed while enabling inline mode:', err);
-        // Fall back to classic editor so the user is not left with a broken inline UI.
-        try {
-            setEditorMode('classic');
-        } catch (fallbackErr) {
-            console.error('Failed to fall back to classic editor mode after inline render failure:', fallbackErr);
-            // As a last resort, at least restore the classic UI visibility.
-            disableInlineEditor();
-        }
+      setEditorMode('classic')
+    } catch (fallbackErr) {
+      console.error(
+        'Failed to fall back to classic editor mode after inline render failure:',
+        fallbackErr
+      )
+      // As a last resort, at least restore the classic UI visibility.
+      disableInlineEditor()
     }
+  }
 }
 
-export function disableInlineEditor() {
-    if (dom.inlinePreview) dom.inlinePreview.classList.add('hidden');
-    if (dom.floatingAddBtn) dom.floatingAddBtn.classList.add('hidden');
-    closeFloatingAddMenu();
-    closeImageResizer();
-    closeLinkEditor();
-    toggleOldUIVisibility(false);
+export function disableInlineEditor () {
+  if (dom.inlinePreview) dom.inlinePreview.classList.add('hidden')
+  if (dom.floatingAddBtn) dom.floatingAddBtn.classList.add('hidden')
+  closeFloatingAddMenu()
+  closeImageResizer()
+  closeLinkEditor()
+  toggleOldUIVisibility(false)
 }
 
-function setEditorMode(mode) {
-    const normalizedMode = mode === 'inline' ? 'inline' : 'classic';
-    recipeData.settings.editorMode = normalizedMode;
-    if (dom.editorModeSelect && dom.editorModeSelect.value !== normalizedMode) {
-        dom.editorModeSelect.value = normalizedMode;
-    }
-    if (normalizedMode === 'inline') enableInlineEditor();
-    else disableInlineEditor();
+function setEditorMode (mode) {
+  const normalizedMode = mode === 'inline' ? 'inline' : 'classic'
+  recipeData.settings.editorMode = normalizedMode
+  if (dom.editorModeSelect && dom.editorModeSelect.value !== normalizedMode) {
+    dom.editorModeSelect.value = normalizedMode
+  }
+  if (normalizedMode === 'inline') enableInlineEditor()
+  else disableInlineEditor()
 }
 
 // --- VIEW TOGGLE ---
 
-function showPreview() {
-    renderPreview();
-    dom.builderPanel.classList.add('hidden');
-    dom.recipePanel.classList.remove('hidden');
-    window.scrollTo(0, 0);
+function showPreview () {
+  renderPreview()
+  dom.builderPanel.classList.add('hidden')
+  dom.recipePanel.classList.remove('hidden')
+  window.scrollTo(0, 0)
 }
 
-function showEditor() {
-    dom.builderPanel.classList.remove('hidden');
-    dom.recipePanel.classList.add('hidden');
-    window.scrollTo(0, 0);
+function showEditor () {
+  dom.builderPanel.classList.remove('hidden')
+  dom.recipePanel.classList.add('hidden')
+  window.scrollTo(0, 0)
 }
 
 // --- PRINT ---
 
-function handlePrint() {
-    const isInline = isInlineMode();
-    if (isInline) document.body.classList.add('print-inline-only');
-    else document.body.classList.add('print-recipe-only');
+function handlePrint () {
+  const isInline = isInlineMode()
+  if (isInline) document.body.classList.add('print-inline-only')
+  else document.body.classList.add('print-recipe-only')
 
-    function cleanup() {
-        document.body.classList.remove('print-inline-only', 'print-recipe-only');
-        window.removeEventListener('afterprint', cleanup);
-    }
+  function cleanup () {
+    document.body.classList.remove('print-inline-only', 'print-recipe-only')
+    window.removeEventListener('afterprint', cleanup)
+  }
 
-    window.addEventListener('afterprint', cleanup);
-    window.print();
-    setTimeout(cleanup, 1500);
+  window.addEventListener('afterprint', cleanup)
+  window.print()
+  setTimeout(cleanup, 1500)
 }
 
 // --- MAIN INPUT HANDLERS ---
 
-function handleUpdateMain(e) {
-    recipeData[e.target.id === 'recipe-title-input' ? 'title' : 'description'] = e.target.value;
+function handleUpdateMain (e) {
+  recipeData[e.target.id === 'recipe-title-input' ? 'title' : 'description'] =
+    e.target.value
 }
 
-function handleLiveInput(e) {
-    const itemEl = e.target.closest('[data-id]');
-    if (!itemEl) return;
+function handleLiveInput (e) {
+  const itemEl = e.target.closest('[data-id]')
+  if (!itemEl) return
 
-    const id = itemEl.dataset.id;
-    const key = e.target.dataset.key;
-    const value = e.target.value;
-    const item = recipeData.items.find(i => i.id == id);
+  const id = itemEl.dataset.id
+  const key = e.target.dataset.key
+  const value = e.target.value
+  const item = recipeData.items.find((i) => i.id == id)
 
-    if (!item || !key) return;
+  if (!item || !key) return
 
-    item[key] = value;
+  item[key] = value
 
-    // If it's the size slider, also update the live pixel display
-    if (key === 'size') {
-        const display = itemEl.querySelector('[data-role="size-display"]');
-        if (display) {
-            display.textContent = `${value}px`;
-        }
+  // If it's the size slider, also update the live pixel display
+  if (key === 'size') {
+    const display = itemEl.querySelector('[data-role="size-display"]')
+    if (display) {
+      display.textContent = `${value}px`
     }
+  }
 }
 
-function handleContentInputClick(e) {
-    const itemEl = e.target.closest('[data-id]');
-    if (!itemEl) return;
+function handleContentInputClick (e) {
+  const itemEl = e.target.closest('[data-id]')
+  if (!itemEl) return
 
-    const id = itemEl.dataset.id;
+  const id = itemEl.dataset.id
 
-    const deleteBtn = e.target.closest('.delete-btn');
-    const moveUpBtn = e.target.closest('.move-up-btn');
-    const moveDownBtn = e.target.closest('.move-down-btn');
+  const deleteBtn = e.target.closest('.delete-btn')
+  const moveUpBtn = e.target.closest('.move-up-btn')
+  const moveDownBtn = e.target.closest('.move-down-btn')
 
-    let actionTaken = false;
+  let actionTaken = false
 
-    if (deleteBtn) {
-        recipeData.items = recipeData.items.filter(i => i.id != id);
-        actionTaken = true;
-    } else if (moveUpBtn) {
-        moveItem(id, 'up');
-        actionTaken = true;
-    } else if (moveDownBtn) {
-        moveItem(id, 'down');
-        actionTaken = true;
-    }
+  if (deleteBtn) {
+    recipeData.items = recipeData.items.filter((i) => i.id != id)
+    actionTaken = true
+  } else if (moveUpBtn) {
+    moveItem(id, 'up')
+    actionTaken = true
+  } else if (moveDownBtn) {
+    moveItem(id, 'down')
+    actionTaken = true
+  }
 
-    if (actionTaken) {
-        renderBuilderInputs();
-        if (isInlineMode()) renderInlinePreview();
-    }
+  if (actionTaken) {
+    renderBuilderInputs()
+    if (isInlineMode()) renderInlinePreview()
+  }
 }
 
 // --- MODAL FUNCTIONS ---
 
-function openToastModal() { dom.toastModal.classList.remove('hidden'); }
-function closeToastModal() { dom.toastModal.classList.add('hidden'); }
-function handleToastSelection(subtype) {
-    closeToastModal();
-    addItem('bubble', subtype);
+function openToastModal () {
+  dom.toastModal.classList.remove('hidden')
+}
+function closeToastModal () {
+  dom.toastModal.classList.add('hidden')
+}
+function handleToastSelection (subtype) {
+  closeToastModal()
+  addItem('bubble', subtype)
 }
 
-function openTextModal() { dom.textModal.classList.remove('hidden'); }
-function closeTextModal() { dom.textModal.classList.add('hidden'); }
-function handleTextSelection(type) {
-    closeTextModal();
-    addItem(type);
+function openTextModal () {
+  dom.textModal.classList.remove('hidden')
+}
+function closeTextModal () {
+  dom.textModal.classList.add('hidden')
+}
+function handleTextSelection (type) {
+  closeTextModal()
+  addItem(type)
 }
 
-function openIconKeyModal() {
-    renderIconList();
-    dom.iconKeyModal.classList.remove('hidden');
-    dom.iconSearchInput.focus();
+function openIconKeyModal () {
+  renderIconList()
+  dom.iconKeyModal.classList.remove('hidden')
+  dom.iconSearchInput.focus()
 }
-function closeIconKeyModal() {
-    dom.iconKeyModal.classList.add('hidden');
-    dom.iconSearchInput.value = '';
+function closeIconKeyModal () {
+  dom.iconKeyModal.classList.add('hidden')
+  dom.iconSearchInput.value = ''
 }
 
-function renderIconList(filter = '') {
-    dom.iconListContainer.innerHTML = '';
-    const lowerFilter = filter.toLowerCase();
-    const filteredIcons = COMMON_ICONS.filter(icon => icon.includes(lowerFilter));
+function renderIconList (filter = '') {
+  dom.iconListContainer.innerHTML = ''
+  const lowerFilter = filter.toLowerCase()
+  const filteredIcons = COMMON_ICONS.filter((icon) =>
+    icon.includes(lowerFilter)
+  )
 
-    if (filteredIcons.length === 0) {
-        dom.iconListContainer.innerHTML = `<p class="text-gray-500 italic">No icons found.</p>`;
-        return;
-    }
+  if (filteredIcons.length === 0) {
+    dom.iconListContainer.innerHTML =
+      '<p class="text-gray-500 italic">No icons found.</p>'
+    return
+  }
 
-    filteredIcons.forEach(icon => {
-        const code = `:${icon}:`;
-        const el = document.createElement('div');
-        el.className = 'flex items-center gap-3 p-2 hover:bg-gray-100 rounded-lg transition-colors duration-100';
-        el.innerHTML = `
+  filteredIcons.forEach((icon) => {
+    const code = `:${icon}:`
+    const el = document.createElement('div')
+    el.className =
+      'flex items-center gap-3 p-2 hover:bg-gray-100 rounded-lg transition-colors duration-100'
+    el.innerHTML = `
             <span class="material-icons text-gray-700">${icon}</span>
             <code class="text-sm text-gray-900 font-mono">${code}</code>
             <button class="copy-icon-btn ml-auto text-xs font-medium bg-blue-100 hover:bg-blue-200 text-blue-700 py-1 px-2 rounded-md transition-all duration-150 active:scale-95" data-code="${code}">Copy</button>
-        `;
-        dom.iconListContainer.appendChild(el);
-    });
+        `
+    dom.iconListContainer.appendChild(el)
+  })
 }
 
-function handleIconListClick(e) {
-    const copyBtn = e.target.closest('.copy-icon-btn');
-    if (copyBtn) {
-        const code = copyBtn.dataset.code;
-        copyToClipboard(code);
-        copyBtn.textContent = 'Copied!';
-        copyBtn.classList.add('bg-green-200', 'text-green-800');
-        setTimeout(() => {
-            copyBtn.textContent = 'Copy';
-            copyBtn.classList.remove('bg-green-200', 'text-green-800');
-        }, 1500);
-    }
+function handleIconListClick (e) {
+  const copyBtn = e.target.closest('.copy-icon-btn')
+  if (copyBtn) {
+    const code = copyBtn.dataset.code
+    copyToClipboard(code)
+    copyBtn.textContent = 'Copied!'
+    copyBtn.classList.add('bg-green-200', 'text-green-800')
+    setTimeout(() => {
+      copyBtn.textContent = 'Copy'
+      copyBtn.classList.remove('bg-green-200', 'text-green-800')
+    }, 1500)
+  }
 }
 
-function openSettingsModal() {
-    dom.globalFontStyleSelect.value = recipeData.settings.fontStyle;
-    if (dom.editorModeSelect) dom.editorModeSelect.value = recipeData.settings.editorMode || 'classic';
-    dom.settingsModal.classList.remove('hidden');
+function openSettingsModal () {
+  dom.globalFontStyleSelect.value = recipeData.settings.fontStyle
+  if (dom.editorModeSelect) {
+    dom.editorModeSelect.value = recipeData.settings.editorMode || 'classic'
+  }
+  dom.settingsModal.classList.remove('hidden')
 }
-function closeSettingsModal() {
-    dom.settingsModal.classList.add('hidden');
+function closeSettingsModal () {
+  dom.settingsModal.classList.add('hidden')
 }
-function handleGlobalFontChange(e) {
-    recipeData.settings.fontStyle = e.target.value;
-    dom.titlePreview.className = `font-style-${recipeData.settings.fontStyle}`;
-    if (isInlineMode()) {
-        renderInlinePreview();
-    }
+function handleGlobalFontChange (e) {
+  recipeData.settings.fontStyle = e.target.value
+  dom.titlePreview.className = `font-style-${recipeData.settings.fontStyle}`
+  if (isInlineMode()) {
+    renderInlinePreview()
+  }
 }
 
 // --- INIT ---
 
-export function init() {
-    // Main info
-    dom.titleInput.addEventListener('input', handleUpdateMain);
-    dom.descInput.addEventListener('input', handleUpdateMain);
+export function init () {
+  // Main info
+  dom.titleInput.addEventListener('input', handleUpdateMain)
+  dom.descInput.addEventListener('input', handleUpdateMain)
 
-    // "Add" buttons
-    dom.addTextBtn.addEventListener('click', openTextModal);
-    dom.addImageBtn.addEventListener('click', () => addItem('image'));
-    dom.addToastBtn.addEventListener('click', openToastModal);
+  // "Add" buttons
+  dom.addTextBtn.addEventListener('click', openTextModal)
+  dom.addImageBtn.addEventListener('click', () => addItem('image'))
+  dom.addToastBtn.addEventListener('click', openToastModal)
 
-    // Toast Modal Listeners
-    dom.closeModalBtn.addEventListener('click', closeToastModal);
-    dom.toastModalOverlay.addEventListener('click', closeToastModal);
-    dom.toastTypeTipBtn.addEventListener('click', () => handleToastSelection('tip'));
-    dom.toastTypeWarningBtn.addEventListener('click', () => handleToastSelection('warning'));
-    dom.toastTypeNoteBtn.addEventListener('click', () => handleToastSelection('note'));
+  // Toast Modal Listeners
+  dom.closeModalBtn.addEventListener('click', closeToastModal)
+  dom.toastModalOverlay.addEventListener('click', closeToastModal)
+  dom.toastTypeTipBtn.addEventListener('click', () =>
+    handleToastSelection('tip')
+  )
+  dom.toastTypeWarningBtn.addEventListener('click', () =>
+    handleToastSelection('warning')
+  )
+  dom.toastTypeNoteBtn.addEventListener('click', () =>
+    handleToastSelection('note')
+  )
 
-    // Text Modal Listeners
-    dom.closeTextModalBtn.addEventListener('click', closeTextModal);
-    dom.textModalOverlay.addEventListener('click', closeTextModal);
-    dom.textTypeHeadingBtn.addEventListener('click', () => handleTextSelection('heading'));
-    dom.textTypeStepBtn.addEventListener('click', () => handleTextSelection('step'));
-    dom.textTypeBulletBtn.addEventListener('click', () => handleTextSelection('bullet'));
-    dom.textTypeTextBtn.addEventListener('click', () => handleTextSelection('text'));
-    dom.textTypeLinkBtn.addEventListener('click', () => handleTextSelection('link'));
+  // Text Modal Listeners
+  dom.closeTextModalBtn.addEventListener('click', closeTextModal)
+  dom.textModalOverlay.addEventListener('click', closeTextModal)
+  dom.textTypeHeadingBtn.addEventListener('click', () =>
+    handleTextSelection('heading')
+  )
+  dom.textTypeStepBtn.addEventListener('click', () =>
+    handleTextSelection('step')
+  )
+  dom.textTypeBulletBtn.addEventListener('click', () =>
+    handleTextSelection('bullet')
+  )
+  dom.textTypeTextBtn.addEventListener('click', () =>
+    handleTextSelection('text')
+  )
+  dom.textTypeLinkBtn.addEventListener('click', () =>
+    handleTextSelection('link')
+  )
 
-    // Icon Key Modal Listeners
-    dom.iconKeyBtn.addEventListener('click', openIconKeyModal);
-    dom.closeIconKeyModalBtn.addEventListener('click', closeIconKeyModal);
-    dom.iconKeyModalOverlay.addEventListener('click', closeIconKeyModal);
-    dom.iconSearchInput.addEventListener('input', (e) => renderIconList(e.target.value));
-    dom.iconListContainer.addEventListener('click', handleIconListClick);
+  // Icon Key Modal Listeners
+  dom.iconKeyBtn.addEventListener('click', openIconKeyModal)
+  dom.closeIconKeyModalBtn.addEventListener('click', closeIconKeyModal)
+  dom.iconKeyModalOverlay.addEventListener('click', closeIconKeyModal)
+  dom.iconSearchInput.addEventListener('input', (e) =>
+    renderIconList(e.target.value)
+  )
+  dom.iconListContainer.addEventListener('click', handleIconListClick)
 
-    // Settings Modal Listeners
-    dom.settingsBtn.addEventListener('click', openSettingsModal);
-    dom.closeSettingsModalBtn.addEventListener('click', closeSettingsModal);
-    dom.settingsModalOverlay.addEventListener('click', closeSettingsModal);
-    dom.globalFontStyleSelect.addEventListener('change', handleGlobalFontChange);
+  // Settings Modal Listeners
+  dom.settingsBtn.addEventListener('click', openSettingsModal)
+  dom.closeSettingsModalBtn.addEventListener('click', closeSettingsModal)
+  dom.settingsModalOverlay.addEventListener('click', closeSettingsModal)
+  dom.globalFontStyleSelect.addEventListener('change', handleGlobalFontChange)
 
-    // Editor Mode select
-    if (dom.editorModeSelect) {
-        dom.editorModeSelect.addEventListener('change', (e) => {
-            setEditorMode(e.target.value);
-        });
-        dom.editorModeSelect.value = recipeData.settings.editorMode || 'classic';
-    }
+  // Editor Mode select
+  if (dom.editorModeSelect) {
+    dom.editorModeSelect.addEventListener('change', (e) => {
+      setEditorMode(e.target.value)
+    })
+    dom.editorModeSelect.value = recipeData.settings.editorMode || 'classic'
+  }
 
-    // Floating add button behavior
-    if (dom.floatingAddBtn) {
-        dom.floatingAddBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            let menu = document.getElementById('floating-add-menu');
-            if (menu) { menu.remove(); return; }
-            menu = document.createElement('div');
-            menu.id = 'floating-add-menu';
-            menu.style.position = 'fixed';
-            menu.style.right = '96px';
-            menu.style.bottom = '24px';
-            menu.style.zIndex = 70;
-            menu.style.background = 'white';
-            menu.style.padding = '8px';
-            menu.style.borderRadius = '8px';
-            menu.style.boxShadow = '0 6px 18px rgba(0,0,0,0.12)';
+  // Floating add button behavior
+  if (dom.floatingAddBtn) {
+    dom.floatingAddBtn.addEventListener('click', (e) => {
+      e.stopPropagation()
+      let menu = document.getElementById('floating-add-menu')
+      if (menu) {
+        menu.remove()
+        return
+      }
+      menu = document.createElement('div')
+      menu.id = 'floating-add-menu'
+      menu.style.position = 'fixed'
+      menu.style.right = '96px'
+      menu.style.bottom = '24px'
+      menu.style.zIndex = 70
+      menu.style.background = 'white'
+      menu.style.padding = '8px'
+      menu.style.borderRadius = '8px'
+      menu.style.boxShadow = '0 6px 18px rgba(0,0,0,0.12)'
 
-            const makeBtn = (label, cb) => {
-                const b = document.createElement('button');
-                b.textContent = label;
-                b.className = 'px-3 py-2 block w-full text-left';
-                b.addEventListener('click', () => { cb(); menu.remove(); });
-                return b;
-            };
+      const makeBtn = (label, cb) => {
+        const b = document.createElement('button')
+        b.textContent = label
+        b.className = 'px-3 py-2 block w-full text-left'
+        b.addEventListener('click', () => {
+          cb()
+          menu.remove()
+        })
+        return b
+      }
 
-            menu.appendChild(makeBtn('Add Text', () => openTextModal()));
-            menu.appendChild(makeBtn('Add Image', () => addItem('image')));
-            menu.appendChild(makeBtn('Add Toast', () => openToastModal()));
-            menu.appendChild(makeBtn('Print', () => handlePrint()));
+      menu.appendChild(makeBtn('Add Text', () => openTextModal()))
+      menu.appendChild(makeBtn('Add Image', () => addItem('image')))
+      menu.appendChild(makeBtn('Add Toast', () => openToastModal()))
+      menu.appendChild(makeBtn('Print', () => handlePrint()))
 
-            document.body.appendChild(menu);
-            // click outside to close
-            setTimeout(() => {
-                document.addEventListener('click', function _close(ev) {
-                    const m = document.getElementById('floating-add-menu');
-                    if (m && !m.contains(ev.target) && ev.target !== dom.floatingAddBtn) m.remove();
-                    document.removeEventListener('click', _close);
-                });
-            }, 10);
-        });
-    }
+      document.body.appendChild(menu)
+      // click outside to close
+      setTimeout(() => {
+        document.addEventListener('click', function _close (ev) {
+          const m = document.getElementById('floating-add-menu')
+          if (m && !m.contains(ev.target) && ev.target !== dom.floatingAddBtn) {
+            m.remove()
+          }
+          document.removeEventListener('click', _close)
+        })
+      }, 10)
+    })
+  }
 
-    // Dynamic item handlers
-    dom.contentInputs.addEventListener('input', handleLiveInput);
-    dom.contentInputs.addEventListener('click', handleContentInputClick);
+  // Dynamic item handlers
+  dom.contentInputs.addEventListener('input', handleLiveInput)
+  dom.contentInputs.addEventListener('click', handleContentInputClick)
 
-    // View Toggle Listeners
-    dom.previewBtn.addEventListener('click', showPreview);
-    dom.editBtn.addEventListener('click', showEditor);
-    dom.printBtn.addEventListener('click', () => handlePrint());
+  // View Toggle Listeners
+  dom.previewBtn.addEventListener('click', showPreview)
+  dom.editBtn.addEventListener('click', showEditor)
+  dom.printBtn.addEventListener('click', () => handlePrint())
 
-    // Initial render
-    renderBuilderInputs();
-    dom.titleInput.value = recipeData.title;
-    dom.descInput.value = recipeData.description;
-    dom.titlePreview.innerHTML = renderIconCodes(recipeData.title);
-    dom.descPreview.innerHTML = renderIconCodes(recipeData.description);
-    dom.globalFontStyleSelect.value = recipeData.settings.fontStyle;
-    dom.titlePreview.className = `font-style-${recipeData.settings.fontStyle}`;
-    // Initialize editor mode (inline is experimental and OFF by default)
-    setEditorMode(recipeData.settings.editorMode);
+  // Initial render
+  renderBuilderInputs()
+  dom.titleInput.value = recipeData.title
+  dom.descInput.value = recipeData.description
+  dom.titlePreview.innerHTML = renderIconCodes(recipeData.title)
+  dom.descPreview.innerHTML = renderIconCodes(recipeData.description)
+  dom.globalFontStyleSelect.value = recipeData.settings.fontStyle
+  dom.titlePreview.className = `font-style-${recipeData.settings.fontStyle}`
+  // Initialize editor mode (inline is experimental and OFF by default)
+  setEditorMode(recipeData.settings.editorMode)
 }

--- a/js/handlers/bullet.js
+++ b/js/handlers/bullet.js
@@ -1,17 +1,17 @@
-import { escapeHTML } from '../helpers.js';
+import { escapeHTML } from '../helpers.js'
 
 /**
  * Returns the builder input configuration for a bullet item.
  * @param {object} item
  * @returns {{ label: string, inputHtml: string }}
  */
-export function getBuilderInput(item) {
-    return {
-        label: 'Bullet',
-        inputHtml: `
+export function getBuilderInput (item) {
+  return {
+    label: 'Bullet',
+    inputHtml: `
             <textarea data-key="content" class="w-full p-2 border border-gray-300 rounded-md" rows="3" placeholder="Enter bullet text">${escapeHTML(item.content)}</textarea>
         `
-    };
+  }
 }
 
 /**
@@ -22,10 +22,10 @@ export function getBuilderInput(item) {
  * @param {string} contentWithIcons - pre-rendered HTML with icon spans
  * @returns {HTMLElement}
  */
-export function renderPreviewElement(item, fontStyle, contentWithIcons) {
-    const el = document.createElement('li');
-    el.innerHTML = contentWithIcons;
-    return el;
+export function renderPreviewElement (item, fontStyle, contentWithIcons) {
+  const el = document.createElement('li')
+  el.innerHTML = contentWithIcons
+  return el
 }
 
 /**
@@ -36,17 +36,17 @@ export function renderPreviewElement(item, fontStyle, contentWithIcons) {
  * @param {string} contentWithIcons - pre-rendered HTML with icon spans
  * @returns {{ badge: HTMLElement, contentSpan: HTMLElement }}
  */
-export function renderInlineElement(item, fontStyle, contentWithIcons) {
-    const badge = document.createElement('span');
-    badge.className = 'bullet-badge';
-    badge.textContent = '•';
+export function renderInlineElement (item, fontStyle, contentWithIcons) {
+  const badge = document.createElement('span')
+  badge.className = 'bullet-badge'
+  badge.textContent = '•'
 
-    const contentSpan = document.createElement('span');
-    contentSpan.className = 'bullet-content';
-    contentSpan.contentEditable = true;
-    contentSpan.dataset.id = item.id;
-    contentSpan.dataset.key = 'content';
-    contentSpan.innerHTML = contentWithIcons;
+  const contentSpan = document.createElement('span')
+  contentSpan.className = 'bullet-content'
+  contentSpan.contentEditable = true
+  contentSpan.dataset.id = item.id
+  contentSpan.dataset.key = 'content'
+  contentSpan.innerHTML = contentWithIcons
 
-    return { badge, contentSpan };
+  return { badge, contentSpan }
 }

--- a/partials/modals.html
+++ b/partials/modals.html
@@ -1,130 +1,260 @@
 <!-- === Toast Type Modal === -->
-<div id="toast-modal" class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4">
-    <!-- Overlay -->
-    <div id="modal-overlay" class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
+<div
+  id="toast-modal"
+  class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4"
+>
+  <!-- Overlay -->
+  <div
+    id="modal-overlay"
+    class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+  ></div>
 
-    <!-- Modal Content -->
-    <div class="relative bg-white w-full max-w-md p-6 rounded-lg shadow-xl font-sans animate-fade-in-down">
-        <div class="flex justify-between items-center mb-4">
-            <h3 class="text-2xl font-bold font-display text-gray-900">Select Toast Type</h3>
-            <button id="close-modal-btn" class="item-btn delete-btn" title="Close">&times;</button>
-        </div>
-        <p class="mb-6 text-gray-600">What kind of toast would you like to add?</p>
-
-        <div class="grid grid-cols-1 gap-4">
-            <button id="toast-type-tip" class="w-full text-left p-4 rounded-lg border-2 border-sky-500 bg-sky-50 hover:bg-sky-100 transition-all">
-                <span class="text-xl font-bold font-display text-sky-700">📘 Tip</span>
-                <p class="text-sky-600 text-sm mt-1">Add a helpful tip, trick, or variation.</p>
-            </button>
-            <button id="toast-type-warning" class="w-full text-left p-4 rounded-lg border-2 border-red-500 bg-red-50 hover:bg-red-100 transition-all">
-                <span class="text-xl font-bold font-display text-red-700">⚠️ Warning</span>
-                <p class="text-red-600 text-sm mt-1">Add an important warning or caution.</p>
-            </button>
-            <button id="toast-type-note" class="w-full text-left p-4 rounded-lg border-2 border-yellow-500 bg-yellow-50 hover:bg-yellow-100 transition-all">
-                <span class="text-xl font-bold font-display text-yellow-700">💡 Note</span>
-                <p class="text-yellow-600 text-sm mt-1">Add a general side note or observation.</p>
-            </button>
-        </div>
+  <!-- Modal Content -->
+  <div
+    class="relative bg-white w-full max-w-md p-6 rounded-lg shadow-xl font-sans animate-fade-in-down"
+  >
+    <div class="flex justify-between items-center mb-4">
+      <h3 class="text-2xl font-bold font-display text-gray-900">
+        Select Toast Type
+      </h3>
+      <button id="close-modal-btn" class="item-btn delete-btn" title="Close">
+        &times;
+      </button>
     </div>
+    <p class="mb-6 text-gray-600">What kind of toast would you like to add?</p>
+
+    <div class="grid grid-cols-1 gap-4">
+      <button
+        id="toast-type-tip"
+        class="w-full text-left p-4 rounded-lg border-2 border-sky-500 bg-sky-50 hover:bg-sky-100 transition-all"
+      >
+        <span class="text-xl font-bold font-display text-sky-700">📘 Tip</span>
+        <p class="text-sky-600 text-sm mt-1">
+          Add a helpful tip, trick, or variation.
+        </p>
+      </button>
+      <button
+        id="toast-type-warning"
+        class="w-full text-left p-4 rounded-lg border-2 border-red-500 bg-red-50 hover:bg-red-100 transition-all"
+      >
+        <span class="text-xl font-bold font-display text-red-700"
+          >⚠️ Warning</span
+        >
+        <p class="text-red-600 text-sm mt-1">
+          Add an important warning or caution.
+        </p>
+      </button>
+      <button
+        id="toast-type-note"
+        class="w-full text-left p-4 rounded-lg border-2 border-yellow-500 bg-yellow-50 hover:bg-yellow-100 transition-all"
+      >
+        <span class="text-xl font-bold font-display text-yellow-700"
+          >💡 Note</span
+        >
+        <p class="text-yellow-600 text-sm mt-1">
+          Add a general side note or observation.
+        </p>
+      </button>
+    </div>
+  </div>
 </div>
 <!-- === End Toast Modal === -->
 
 <!-- === Text Type Modal === -->
-<div id="text-modal" class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4">
-    <!-- Overlay -->
-    <div id="modal-overlay-text" class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
+<div
+  id="text-modal"
+  class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4"
+>
+  <!-- Overlay -->
+  <div
+    id="modal-overlay-text"
+    class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+  ></div>
 
-    <!-- Modal Content -->
-    <div class="relative bg-white w-full max-w-md p-6 rounded-lg shadow-xl font-sans animate-fade-in-down">
-        <div class="flex justify-between items-center mb-4">
-            <h3 class="text-2xl font-bold font-display text-gray-900">Select Text Type</h3>
-            <button id="close-text-modal-btn" class="item-btn delete-btn" title="Close">&times;</button>
-        </div>
-        <p class="mb-6 text-gray-600">What kind of text would you like to add?</p>
-
-        <div class="grid grid-cols-1 gap-4">
-            <button id="text-type-heading" class="w-full text-left p-4 rounded-lg border-2 border-sky-500 bg-sky-50 hover:bg-sky-100 transition-all">
-                <span class="text-xl font-bold font-display text-sky-700">Heading</span>
-                <p class="text-sky-600 text-sm mt-1">Add a new section heading.</p>
-            </button>
-            <button id="text-type-step" class="w-full text-left p-4 rounded-lg border-2 border-gray-500 bg-gray-50 hover:bg-gray-100 transition-all">
-                <span class="text-xl font-bold font-display text-gray-700">1. Step</span>
-                <p class="text-gray-600 text-sm mt-1">Add a numbered step to a list.</p>
-            </button>
-            <button id="text-type-bullet" class="w-full text-left p-4 rounded-lg border-2 border-gray-500 bg-gray-50 hover:bg-gray-100 transition-all">
-                <span class="text-xl font-bold font-display text-gray-700">• Bullet</span>
-                <p class="text-gray-600 text-sm mt-1">Add a bulleted list item.</p>
-            </button>
-            <button id="text-type-text" class="w-full text-left p-4 rounded-lg border-2 border-gray-500 bg-gray-50 hover:bg-gray-100 transition-all">
-                <span class="text-xl font-bold font-display text-gray-700">¶ Text</span>
-                <p class="text-gray-600 text-sm mt-1">Add a plain paragraph of text.</p>
-            </button>
-            <button id="text-type-link" class="w-full text-left p-4 rounded-lg border-2 border-blue-500 bg-blue-50 hover:bg-blue-100 transition-all">
-                <span class="text-xl font-bold font-display text-blue-700 flex items-center gap-1"><span class="material-icons align-middle text-xl">link</span> Link</span>
-                <p class="text-blue-600 text-sm mt-1">Add a clickable hyperlink with custom text.</p>
-            </button>
-        </div>
+  <!-- Modal Content -->
+  <div
+    class="relative bg-white w-full max-w-md p-6 rounded-lg shadow-xl font-sans animate-fade-in-down"
+  >
+    <div class="flex justify-between items-center mb-4">
+      <h3 class="text-2xl font-bold font-display text-gray-900">
+        Select Text Type
+      </h3>
+      <button
+        id="close-text-modal-btn"
+        class="item-btn delete-btn"
+        title="Close"
+      >
+        &times;
+      </button>
     </div>
+    <p class="mb-6 text-gray-600">What kind of text would you like to add?</p>
+
+    <div class="grid grid-cols-1 gap-4">
+      <button
+        id="text-type-heading"
+        class="w-full text-left p-4 rounded-lg border-2 border-sky-500 bg-sky-50 hover:bg-sky-100 transition-all"
+      >
+        <span class="text-xl font-bold font-display text-sky-700">Heading</span>
+        <p class="text-sky-600 text-sm mt-1">Add a new section heading.</p>
+      </button>
+      <button
+        id="text-type-step"
+        class="w-full text-left p-4 rounded-lg border-2 border-gray-500 bg-gray-50 hover:bg-gray-100 transition-all"
+      >
+        <span class="text-xl font-bold font-display text-gray-700"
+          >1. Step</span
+        >
+        <p class="text-gray-600 text-sm mt-1">Add a numbered step to a list.</p>
+      </button>
+      <button
+        id="text-type-bullet"
+        class="w-full text-left p-4 rounded-lg border-2 border-gray-500 bg-gray-50 hover:bg-gray-100 transition-all"
+      >
+        <span class="text-xl font-bold font-display text-gray-700"
+          >• Bullet</span
+        >
+        <p class="text-gray-600 text-sm mt-1">Add a bulleted list item.</p>
+      </button>
+      <button
+        id="text-type-text"
+        class="w-full text-left p-4 rounded-lg border-2 border-gray-500 bg-gray-50 hover:bg-gray-100 transition-all"
+      >
+        <span class="text-xl font-bold font-display text-gray-700">¶ Text</span>
+        <p class="text-gray-600 text-sm mt-1">Add a plain paragraph of text.</p>
+      </button>
+      <button
+        id="text-type-link"
+        class="w-full text-left p-4 rounded-lg border-2 border-blue-500 bg-blue-50 hover:bg-blue-100 transition-all"
+      >
+        <span
+          class="text-xl font-bold font-display text-blue-700 flex items-center gap-1"
+          ><span class="material-icons align-middle text-xl">link</span>
+          Link</span
+        >
+        <p class="text-blue-600 text-sm mt-1">
+          Add a clickable hyperlink with custom text.
+        </p>
+      </button>
+    </div>
+  </div>
 </div>
 <!-- === End Text Modal === -->
 
 <!-- === Icon Key Modal === -->
-<div id="icon-key-modal" class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4">
-    <!-- Overlay -->
-    <div id="icon-key-modal-overlay" class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
+<div
+  id="icon-key-modal"
+  class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4"
+>
+  <!-- Overlay -->
+  <div
+    id="icon-key-modal-overlay"
+    class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+  ></div>
 
-    <!-- Modal Content -->
-    <div class="relative bg-white w-full max-w-lg p-6 rounded-lg shadow-xl font-sans animate-fade-in-down flex flex-col" style="max-height: 80vh;">
-        <div class="flex justify-between items-center mb-4 pb-4 border-b border-gray-200">
-            <h3 class="text-2xl font-bold font-display text-gray-900">Icon Key</h3>
-            <button id="close-icon-key-modal-btn" class="item-btn delete-btn" title="Close">&times;</button>
-        </div>
-
-        <!-- Search Bar -->
-        <div class="mb-4">
-            <label for="icon-search-input" class="sr-only">Search icons</label>
-            <input type="search" id="icon-search-input" placeholder="Search icons... (e.g., 'timer')" class="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
-        </div>
-
-        <!-- Icon List Container -->
-        <div id="icon-list-container" class="flex-grow overflow-y-auto space-y-2 pr-2">
-            <!-- JS will populate this -->
-        </div>
+  <!-- Modal Content -->
+  <div
+    class="relative bg-white w-full max-w-lg p-6 rounded-lg shadow-xl font-sans animate-fade-in-down flex flex-col"
+    style="max-height: 80vh"
+  >
+    <div
+      class="flex justify-between items-center mb-4 pb-4 border-b border-gray-200"
+    >
+      <h3 class="text-2xl font-bold font-display text-gray-900">Icon Key</h3>
+      <button
+        id="close-icon-key-modal-btn"
+        class="item-btn delete-btn"
+        title="Close"
+      >
+        &times;
+      </button>
     </div>
+
+    <!-- Search Bar -->
+    <div class="mb-4">
+      <label for="icon-search-input" class="sr-only">Search icons</label>
+      <input
+        type="search"
+        id="icon-search-input"
+        placeholder="Search icons... (e.g., 'timer')"
+        class="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+      />
+    </div>
+
+    <!-- Icon List Container -->
+    <div
+      id="icon-list-container"
+      class="flex-grow overflow-y-auto space-y-2 pr-2"
+    >
+      <!-- JS will populate this -->
+    </div>
+  </div>
 </div>
 <!-- === End Icon Key Modal === -->
 
 <!-- === Settings Modal === -->
-<div id="settings-modal" class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4">
-    <!-- Overlay -->
-    <div id="settings-modal-overlay" class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
+<div
+  id="settings-modal"
+  class="hidden no-print fixed inset-0 z-50 flex items-center justify-center p-4"
+>
+  <!-- Overlay -->
+  <div
+    id="settings-modal-overlay"
+    class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+  ></div>
 
-    <!-- Modal Content -->
-    <div class="relative bg-white w-full max-w-md p-6 rounded-lg shadow-xl font-sans animate-fade-in-down">
-        <div class="flex justify-between items-center mb-4">
-            <h3 class="text-2xl font-bold font-display text-gray-900">Settings</h3>
-            <button id="close-settings-modal-btn" class="item-btn delete-btn" title="Close">&times;</button>
-        </div>
-
-        <div class="space-y-4">
-            <div>
-                <label for="global-font-style-select" class="block text-sm font-medium text-gray-700 mb-1">Global Heading Font</label>
-                <select id="global-font-style-select" class="w-full p-2 border border-gray-300 rounded-md bg-white shadow-sm">
-                    <option value="display">Playful (Baloo 2)</option>
-                    <option value="serif">Serif (Merriweather)</option>
-                    <option value="sans">Sans-Serif (Lexend)</option>
-                </select>
-                <p class="text-xs text-gray-500 mt-1">Controls the font for the main title and all headings.</p>
-            </div>
-            <div>
-                <label for="editor-mode-select" class="block text-sm font-medium text-gray-700 mb-1">Editor Mode</label>
-                <select id="editor-mode-select" class="w-full p-2 border border-gray-300 rounded-md bg-white shadow-sm">
-                    <option value="classic">Classic Editor (current)</option>
-                    <option value="inline">Inline Live Editor (experimental)</option>
-                </select>
-                <p class="text-xs text-gray-500 mt-1">Inline Live Editor shows a live preview on the page and allows editing by clicking. Not enabled by default.</p>
-            </div>
-        </div>
+  <!-- Modal Content -->
+  <div
+    class="relative bg-white w-full max-w-md p-6 rounded-lg shadow-xl font-sans animate-fade-in-down"
+  >
+    <div class="flex justify-between items-center mb-4">
+      <h3 class="text-2xl font-bold font-display text-gray-900">Settings</h3>
+      <button
+        id="close-settings-modal-btn"
+        class="item-btn delete-btn"
+        title="Close"
+      >
+        &times;
+      </button>
     </div>
+
+    <div class="space-y-4">
+      <div>
+        <label
+          for="global-font-style-select"
+          class="block text-sm font-medium text-gray-700 mb-1"
+          >Global Heading Font</label
+        >
+        <select
+          id="global-font-style-select"
+          class="w-full p-2 border border-gray-300 rounded-md bg-white shadow-sm"
+        >
+          <option value="display">Playful (Baloo 2)</option>
+          <option value="serif">Serif (Merriweather)</option>
+          <option value="sans">Sans-Serif (Lexend)</option>
+        </select>
+        <p class="text-xs text-gray-500 mt-1">
+          Controls the font for the main title and all headings.
+        </p>
+      </div>
+      <div>
+        <label
+          for="editor-mode-select"
+          class="block text-sm font-medium text-gray-700 mb-1"
+          >Editor Mode</label
+        >
+        <select
+          id="editor-mode-select"
+          class="w-full p-2 border border-gray-300 rounded-md bg-white shadow-sm"
+        >
+          <option value="classic">Classic Editor (current)</option>
+          <option value="inline">Inline Live Editor (experimental)</option>
+        </select>
+        <p class="text-xs text-gray-500 mt-1">
+          Inline Live Editor shows a live preview on the page and allows editing
+          by clicking. Not enabled by default.
+        </p>
+      </div>
+    </div>
+  </div>
 </div>
 <!-- === End Settings Modal === -->

--- a/styles.css
+++ b/styles.css
@@ -1,440 +1,501 @@
 /* --- Base Styles (from user's original file) --- */
 .recipe-preview-content {
-    font-family: 'Lexend', Arial, 'sans-serif';
-    line-height: 1.6;
-    color: #333;
+  font-family: "Lexend", Arial, "sans-serif";
+  line-height: 1.6;
+  color: #333;
 }
 
 /* --- UPDATED: Font styling for headings --- */
 /* h1 (title) and h3 (unused) base styles */
-.recipe-preview-content h1, 
+.recipe-preview-content h1,
 .recipe-preview-content h3 {
-    /* font-family removed, will be applied by class */
-    font-weight: 700;
-    color: #222;
+  /* font-family removed, will be applied by class */
+  font-weight: 700;
+  color: #222;
 }
 .recipe-preview-content h1 {
-    text-align: center;
-    border-bottom: 2px solid #eee;
-    padding-bottom: 10px;
-    font-size: 2.25rem; /* Tailwind text-4xl */
+  text-align: center;
+  border-bottom: 2px solid #eee;
+  padding-bottom: 10px;
+  font-size: 2.25rem; /* Tailwind text-4xl */
 }
 /* h2 (dynamic headings) gets base styles */
 .recipe-preview-content h2 {
-    font-weight: 700;
-    color: #222;
-    border-bottom: 1px solid #eee;
-    padding-bottom: 5px;
-    margin-top: 30px;
-    font-size: 1.875rem; /* Tailwind text-3xl */
+  font-weight: 700;
+  color: #222;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 5px;
+  margin-top: 30px;
+  font-size: 1.875rem; /* Tailwind text-3xl */
 }
 
 /* NEW: Dynamic font classes for h1 AND h2 */
 .recipe-preview-content h1.font-style-display,
-.recipe-preview-content h2.font-style-display { font-family: '"Baloo 2"', cursive; }
+.recipe-preview-content h2.font-style-display {
+  font-family: '"Baloo 2"', cursive;
+}
 
 .recipe-preview-content h1.font-style-serif,
-.recipe-preview-content h2.font-style-serif { font-family: 'Merriweather', serif; }
+.recipe-preview-content h2.font-style-serif {
+  font-family: "Merriweather", serif;
+}
 
 .recipe-preview-content h1.font-style-sans,
-.recipe-preview-content h2.font-style-sans { font-family: 'Lexend', sans-serif; }
-
+.recipe-preview-content h2.font-style-sans {
+  font-family: "Lexend", sans-serif;
+}
 
 .recipe-preview-content h3 {
-    margin-top: 25px;
-    font-style: normal;
-    font-weight: 700;
-    font-size: 1.5rem; /* Tailwind text-2xl */
+  margin-top: 25px;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.5rem; /* Tailwind text-2xl */
 }
 /* --- End of heading font update --- */
 
-.recipe-preview-content ul, 
+.recipe-preview-content ul,
 .recipe-preview-content ol {
-    padding-left: 30px;
-    list-style-position: outside;
+  padding-left: 30px;
+  list-style-position: outside;
 }
 .recipe-preview-content ol {
-    list-style-type: decimal;
+  list-style-type: decimal;
 }
 .recipe-preview-content ul {
-    list-style-type: disc;
+  list-style-type: disc;
 }
 .recipe-preview-content li {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 .recipe-preview-content img {
-    display: block;
-    height: auto;
-    margin: 20px auto;
-    border-radius: 8px;
-    background-color: #f0f0f0;
-    object-fit: cover;
+  display: block;
+  height: auto;
+  margin: 20px auto;
+  border-radius: 8px;
+  background-color: #f0f0f0;
+  object-fit: cover;
 }
 
-
 .recipe-preview-content p#recipe-desc-preview {
-    text-align: center;
-    font-style: italic;
-    color: #555;
-    margin-bottom: 1rem;
+  text-align: center;
+  font-style: italic;
+  color: #555;
+  margin-bottom: 1rem;
 }
 /* --- End of Original Styles --- */
 
 /* --- New Plain Text Block Style --- */
 .recipe-text-block {
-    text-align: left;
-    font-style: normal;
-    color: #333;
-    margin: 1rem 0;
-    line-height: 1.6;
+  text-align: left;
+  font-style: normal;
+  color: #333;
+  margin: 1rem 0;
+  line-height: 1.6;
 }
 
 /* --- New "Text Bubble" Style (Stylized as a sticky note) --- */
 /* Base style for all "toasts" */
 .toast-base {
-    border-radius: 8px;
-    padding: 12px 16px;
-    margin: 20px 0;
-    font-family: 'Kalam', cursive; /* Playful font */
-    font-size: 1.1rem; /* Slightly larger */
-    box-shadow: 2px 2px 10px rgba(0,0,0,0.05);
-    transform: rotate(-1deg); /* Slight playful tilt */
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 20px 0;
+  font-family: "Kalam", cursive; /* Playful font */
+  font-size: 1.1rem; /* Slightly larger */
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.05);
+  transform: rotate(-1deg); /* Slight playful tilt */
 }
 .toast-base::before {
-    font-weight: 700;
-    font-style: normal;
+  font-weight: 700;
+  font-style: normal;
 }
 
 /* Note Style (Yellow) */
 .toast-note {
-    background-color: #fefce8; /* yellow-50 */
-    border-left: 5px solid #eab308; /* yellow-500 */
-    color: #713f12; /* yellow-900 */
+  background-color: #fefce8; /* yellow-50 */
+  border-left: 5px solid #eab308; /* yellow-500 */
+  color: #713f12; /* yellow-900 */
 }
 .toast-note::before {
-    content: '💡 Note: ';
+  content: "💡 Note: ";
 }
 
 /* Tip Style (Blue) */
 .toast-tip {
-    background-color: #e0f2fe; /* light-blue-100 */
-    border-left: 5px solid #0ea5e9; /* sky-500 */
-    color: #0c4a6e; /* sky-900 */
+  background-color: #e0f2fe; /* light-blue-100 */
+  border-left: 5px solid #0ea5e9; /* sky-500 */
+  color: #0c4a6e; /* sky-900 */
 }
 .toast-tip::before {
-    content: '📘 Tip: ';
+  content: "📘 Tip: ";
 }
 
 /* Warning Style (Red) */
 .toast-warning {
-    background-color: #fef2f2; /* red-50 */
-    border-left: 5px solid #ef4444; /* red-500 */
-    color: #991b1b; /* red-900 */
+  background-color: #fef2f2; /* red-50 */
+  border-left: 5px solid #ef4444; /* red-500 */
+  color: #991b1b; /* red-900 */
 }
 .toast-warning::before {
-    content: '⚠️ Warning: ';
+  content: "⚠️ Warning: ";
 }
-
 
 /* --- Builder & Print Styles --- */
 /* Base style for all item buttons (move, delete) */
 .item-btn {
-    font-weight: bold;
-    cursor: pointer;
-    font-size: 1.25rem;
-    line-height: 1;
-    transition: all 0.2s ease;
+  font-weight: bold;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  transition: all 0.2s ease;
 }
 
 /* New Move Button Styles */
-.move-up-btn, .move-down-btn {
-    color: #3b82f6; /* blue-500 */
+.move-up-btn,
+.move-down-btn {
+  color: #3b82f6; /* blue-500 */
 }
-.move-up-btn:hover, .move-down-btn:hover {
-    color: #1d4ed8; /* blue-700 */
-    transform: scale(1.25);
+.move-up-btn:hover,
+.move-down-btn:hover {
+  color: #1d4ed8; /* blue-700 */
+  transform: scale(1.25);
 }
 /* Class to hide arrows when at top/bottom */
 .hidden-arrow {
-    visibility: hidden;
-    cursor: default;
+  visibility: hidden;
+  cursor: default;
 }
 .hidden-arrow:hover {
-    transform: none;
-    color: inherit;
+  transform: none;
+  color: inherit;
 }
 
 .delete-btn {
-    color: #ef4444; /* red-500 */
+  color: #ef4444; /* red-500 */
 }
 .delete-btn:hover {
-    color: #b91c1c; /* red-700 */
-    transform: scale(1.25) rotate(10deg); /* Added playful hover */
+  color: #b91c1c; /* red-700 */
+  transform: scale(1.25) rotate(10deg); /* Added playful hover */
 }
 
 /* --- NEW: Material Icons Base Style --- */
 .material-icons {
-    font-family: 'Material Icons';
-    font-weight: normal;
-    font-style: normal;
-    font-size: 24px;  /* Default icon size */
-    display: inline-block;
-    line-height: 1;
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: normal;
-    white-space: nowrap;
-    direction: ltr;
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
-    -moz-osx-font-smoothing: grayscale;
-    font-feature-settings: 'liga';
+  font-family: "Material Icons";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px; /* Default icon size */
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "liga";
 }
 
 /* --- NEW: Inline Icon Style for Preview --- */
 .recipe-preview-content .material-icons {
-    font-size: 1.1em; /* Make icon match text size */
-    vertical-align: -0.15em; /* Align icon nicely with text */
-    line-height: 1;
+  font-size: 1.1em; /* Make icon match text size */
+  vertical-align: -0.15em; /* Align icon nicely with text */
+  line-height: 1;
 }
 
 @media print {
-    /* Hide the builder panel and all buttons */
-    .builder-panel, .no-print, .preview-controls {
-        display: none !important;
-    }
+  /* Hide the builder panel and all buttons */
+  .builder-panel,
+  .no-print,
+  .preview-controls {
+    display: none !important;
+  }
 
-    /* Make the recipe panel take full width */
-    .recipe-panel {
-        width: 100%;
-        padding: 0;
-        margin: 0;
-        display: block !important; /* Ensure it's visible for print */
-    }
+  /* Make the recipe panel take full width */
+  .recipe-panel {
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    display: block !important; /* Ensure it's visible for print */
+  }
 
-    body {
-        background-color: #ffffff;
-        margin: 0;
-        padding: 0;
-        font-family: 'Lexend', sans-serif;
-        color: #000;
-    }
+  body {
+    background-color: #ffffff;
+    margin: 0;
+    padding: 0;
+    font-family: "Lexend", sans-serif;
+    color: #000;
+  }
 
-    /* Reset recipe container for printing */
-    .recipe-preview-content.container {
-        width: 100%;
-        max-width: 100%;
-        margin: 0;
-        padding: 0;
-        border: none;
-        box-shadow: none;
-    }
+  /* Reset recipe container for printing */
+  .recipe-preview-content.container {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+  }
 
-    /* Ensure images print well */
-    .recipe-preview-content img {
-        /* Allow the inline `style="max-width:...px"` set by the preview to take precedence
+  /* Ensure images print well */
+  .recipe-preview-content img {
+    /* Allow the inline `style="max-width:...px"` set by the preview to take precedence
            while still preventing images from overflowing the printed page. Removing the
            previous `!important` cap lets element inline styles (the user's chosen size)
            apply. Use max-width:100% so very large values still fit the page. */
-        max-width: 100%;
-        height: auto;
-        display: block;
-        margin: 20px auto;
-        page-break-inside: avoid;
-    }
-    
-    /* Style text bubble for print */
-    .text-bubble, .toast-base {
-        background-color: #f8f8f8 !important;
-        border: 1px solid #ddd !important;
-        color: #333 !important;
-        font-family: 'Lexend', sans-serif !important; /* Reset font for print */
-        font-style: italic;
-        font-size: 1rem;
-        transform: rotate(0deg); /* Straighten for print */
-        page-break-inside: avoid;
-    }
-    .text-bubble::before, .toast-base::before {
-        color: #000 !important;
-        font-family: 'Lexend', sans-serif !important;
-    }
-    /* Specific print "before" content */
-    .toast-note::before { content: 'Note: '; }
-    .toast-tip::before { content: 'Tip: '; }
-    .toast-warning::before { content: 'Warning: '; }
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 20px auto;
+    page-break-inside: avoid;
+  }
 
-    /* --- NEW: Hide icons in print only for UI chrome areas (not the recipe preview) --- */
-    .no-print .material-icons, .builder-panel .material-icons, .preview-controls .material-icons {
-        display: none !important;
-    }
+  /* Style text bubble for print */
+  .text-bubble,
+  .toast-base {
+    background-color: #f8f8f8 !important;
+    border: 1px solid #ddd !important;
+    color: #333 !important;
+    font-family: "Lexend", sans-serif !important; /* Reset font for print */
+    font-style: italic;
+    font-size: 1rem;
+    transform: rotate(0deg); /* Straighten for print */
+    page-break-inside: avoid;
+  }
+  .text-bubble::before,
+  .toast-base::before {
+    color: #000 !important;
+    font-family: "Lexend", sans-serif !important;
+  }
+  /* Specific print "before" content */
+  .toast-note::before {
+    content: "Note: ";
+  }
+  .toast-tip::before {
+    content: "Tip: ";
+  }
+  .toast-warning::before {
+    content: "Warning: ";
+  }
 
-    /* General print typography */
-    .recipe-preview-content h1, 
-    .recipe-preview-content h3 {
-        color: #000;
-        /* font-family applied by class */
-    }
-    /* UPDATED: h1/h2 print styles */
-    .recipe-preview-content h1,
-    .recipe-preview-content h2 { color: #000; }
-    
-    .recipe-preview-content h1.font-style-display,
-    .recipe-preview-content h2.font-style-display { font-family: '"Baloo 2"', cursive; }
-    
-    .recipe-preview-content h1.font-style-serif,
-    .recipe-preview-content h2.font-style-serif { font-family: 'Merriweather', serif; }
-    
-    .recipe-preview-content h1.font-style-sans,
-    .recipe-preview-content h2.font-style-sans { font-family: 'Lexend', sans-serif; }
+  /* --- NEW: Hide icons in print only for UI chrome areas (not the recipe preview) --- */
+  .no-print .material-icons,
+  .builder-panel .material-icons,
+  .preview-controls .material-icons {
+    display: none !important;
+  }
 
+  /* General print typography */
+  .recipe-preview-content h1,
+  .recipe-preview-content h3 {
+    color: #000;
+    /* font-family applied by class */
+  }
+  /* UPDATED: h1/h2 print styles */
+  .recipe-preview-content h1,
+  .recipe-preview-content h2 {
+    color: #000;
+  }
 
-    .recipe-preview-content p#recipe-desc-preview, 
-    .recipe-preview-content li,
-    .recipe-text-block {
-        color: #000;
-    }
+  .recipe-preview-content h1.font-style-display,
+  .recipe-preview-content h2.font-style-display {
+    font-family: '"Baloo 2"', cursive;
+  }
 
-    .recipe-preview-content li {
-        color: #000;
-    }
+  .recipe-preview-content h1.font-style-serif,
+  .recipe-preview-content h2.font-style-serif {
+    font-family: "Merriweather", serif;
+  }
 
-    /* Prevent page breaks where we don't want them */
-    .recipe-preview-content li, 
-    .recipe-preview-content h2, 
-    .recipe-preview-content h3 {
-        page-break-after: avoid;
-        page-break-inside: avoid;
-    }
-    .recipe-preview-content h1 {
-        page-break-after: avoid;
-    }
+  .recipe-preview-content h1.font-style-sans,
+  .recipe-preview-content h2.font-style-sans {
+    font-family: "Lexend", sans-serif;
+  }
+
+  .recipe-preview-content p#recipe-desc-preview,
+  .recipe-preview-content li,
+  .recipe-text-block {
+    color: #000;
+  }
+
+  .recipe-preview-content li {
+    color: #000;
+  }
+
+  /* Prevent page breaks where we don't want them */
+  .recipe-preview-content li,
+  .recipe-preview-content h2,
+  .recipe-preview-content h3 {
+    page-break-after: avoid;
+    page-break-inside: avoid;
+  }
+  .recipe-preview-content h1 {
+    page-break-after: avoid;
+  }
 }
 
 /* --- Inline Editor & Floating Add Button Styles --- */
 .inline-edit-image {
-    cursor: pointer;
-    border-radius: 6px;
-    transition: box-shadow 0.15s ease, transform 0.12s ease;
+  cursor: pointer;
+  border-radius: 6px;
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.12s ease;
 }
 .inline-edit-image:hover {
-    box-shadow: 0 8px 20px rgba(0,0,0,0.08);
-    transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
 }
 
 .image-resizer-overlay input[type="range"] {
-    appearance: none;
-    -webkit-appearance: none;
-    height: 6px;
-    border-radius: 6px;
-    background: linear-gradient(90deg,#60a5fa,#7c3aed);
+  appearance: none;
+  -webkit-appearance: none;
+  height: 6px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #60a5fa, #7c3aed);
 }
 
 /* Floating add menu default styles (menu created dynamically) */
-#floating-add-menu button:hover { background: #f3f4f6; }
+#floating-add-menu button:hover {
+  background: #f3f4f6;
+}
 
 /* Ensure inline preview looks like the recipe preview */
-#inline-preview .recipe-text-block { margin: 0.75rem 0; }
+#inline-preview .recipe-text-block {
+  margin: 0.75rem 0;
+}
 #inline-preview .inline-edit-link {
-    cursor: pointer;
+  cursor: pointer;
 }
 #inline-preview .inline-edit-link:hover {
-    text-decoration-style: dashed;
+  text-decoration-style: dashed;
 }
 
 /* Global font-style helper classes so inline preview headings respect settings */
-.font-style-display { font-family: '"Baloo 2"', cursive !important; }
-.font-style-serif { font-family: 'Merriweather', serif !important; }
-.font-style-sans { font-family: 'Lexend', sans-serif !important; }
+.font-style-display {
+  font-family: '"Baloo 2"', cursive !important;
+}
+.font-style-serif {
+  font-family: "Merriweather", serif !important;
+}
+.font-style-sans {
+  font-family: "Lexend", sans-serif !important;
+}
 
 /* New text outline to make freshly added text visible */
 .new-text-outline {
-    outline: 2px dashed rgba(59,130,246,0.6); /* blue-500-ish */
-    padding: 2px;
-    border-radius: 4px;
+  outline: 2px dashed rgba(59, 130, 246, 0.6); /* blue-500-ish */
+  padding: 2px;
+  border-radius: 4px;
 }
 
 /* Inline item wrapper */
 .inline-item {
-    cursor: grab;
+  cursor: grab;
 }
 .inline-item.dragging {
-    opacity: 0.5;
+  opacity: 0.5;
 }
 .inline-item.drop-target {
-    outline: 2px solid rgba(79,70,229,0.25);
+  outline: 2px solid rgba(79, 70, 229, 0.25);
 }
 
 /* Step badge styling (numbered prefix for inline steps) */
 .step-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 9999px;
-    background: #e5e7eb; /* gray-200 */
-    border: 1px solid #d1d5db; /* gray-300 */
-    color: #111827; /* gray-900 */
-    font-weight: 700;
-    flex: 0 0 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  background: #e5e7eb; /* gray-200 */
+  border: 1px solid #d1d5db; /* gray-300 */
+  color: #111827; /* gray-900 */
+  font-weight: 700;
+  flex: 0 0 32px;
 }
 .step-content {
-    display: inline;
-    padding-top: 4px;
+  display: inline;
+  padding-top: 4px;
 }
 .bullet-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 9999px;
-    background: #e5e7eb; /* gray-200 */
-    border: 1px solid #d1d5db; /* gray-300 */
-    color: #111827; /* gray-900 */
-    font-size: 1.6rem;
-    line-height: 1;
-    flex: 0 0 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  background: #e5e7eb; /* gray-200 */
+  border: 1px solid #d1d5db; /* gray-300 */
+  color: #111827; /* gray-900 */
+  font-size: 1.6rem;
+  line-height: 1;
+  flex: 0 0 32px;
 }
 .bullet-content {
-    display: inline;
-    padding-top: 4px;
+  display: inline;
+  padding-top: 4px;
 }
 
 #inline-preview .inline-step-list,
 #inline-preview .inline-bullet-list {
-    list-style: none;
-    margin: 0.75rem 0;
-    padding-left: 0;
+  list-style: none;
+  margin: 0.75rem 0;
+  padding-left: 0;
 }
 #inline-preview .inline-list-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-    margin-bottom: 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 10px;
 }
 #inline-preview .inline-list-item:last-child {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
-
 
 /* Print helpers: when JS adds body.print-inline-only or body.print-recipe-only
    we make only the chosen preview visible for printing. This prevents UI chrome
    from appearing in the printout when using the experimental inline editor. */
 @media print {
-    /* Hide everything first */
-    body.print-inline-only * { visibility: hidden !important; }
-    /* Show inline preview only */
-    body.print-inline-only #inline-preview, body.print-inline-only #inline-preview * { visibility: visible !important; }
-    body.print-inline-only #inline-preview { position: absolute; left: 0; top: 0; width: 100%; }
+  /* Hide everything first */
+  body.print-inline-only * {
+    visibility: hidden !important;
+  }
+  /* Show inline preview only */
+  body.print-inline-only #inline-preview,
+  body.print-inline-only #inline-preview * {
+    visibility: visible !important;
+  }
+  body.print-inline-only #inline-preview {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+  }
 
-    /* Classic/preview-only print (used when printing from the recipe preview) */
-    body.print-recipe-only * { visibility: hidden !important; }
-    body.print-recipe-only #recipe-preview, body.print-recipe-only #recipe-preview * { visibility: visible !important; }
-    body.print-recipe-only #recipe-preview { position: absolute; left: 0; top: 0; width: 100%; }
+  /* Classic/preview-only print (used when printing from the recipe preview) */
+  body.print-recipe-only * {
+    visibility: hidden !important;
+  }
+  body.print-recipe-only #recipe-preview,
+  body.print-recipe-only #recipe-preview * {
+    visibility: visible !important;
+  }
+  body.print-recipe-only #recipe-preview {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+  }
 
-    /* Ensure we don't print editor outlines or floating controls */
-    .new-text-outline { outline: none !important; padding: 0 !important; }
-    #floating-add-btn, #icon-key-btn, #settings-btn { display: none !important; }
+  /* Ensure we don't print editor outlines or floating controls */
+  .new-text-outline {
+    outline: none !important;
+    padding: 0 !important;
+  }
+  #floating-add-btn,
+  #icon-key-btn,
+  #settings-btn {
+    display: none !important;
+  }
 }
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `bullet` text item type in the text selection modal
- wire bullet items into builder input rendering and state item creation
- render bullet items as `<ul>` sequences in classic preview
- render bullet items in inline mode with a step-like badge layout for visual consistency
- refine inline badge styling so step and bullet badges are clearly visible
- apply explicit bullet-handler imports to satisfy static review feedback

## Testing Plan
- manual browser verification in classic mode preview for proper bullet rendering
- manual browser verification in inline mode for bullet styling and editing behavior

Closes #3
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5926437-3070-450f-ab28-e229a5b54b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5926437-3070-450f-ab28-e229a5b54b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

