### PR TITLE
Fix inline paged page alignment in multi-page preview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -285,6 +285,7 @@
 #recipe-panel.paged-preview-active #recipe-flow {
   column-width: var(--preview-page-width);
   column-gap: var(--preview-page-gap);
+  column-fill: auto;
   height: var(--preview-page-height);
   width: 100%;
   max-width: 100%;
@@ -559,6 +560,7 @@
 #inline-preview.inline-paged-preview-active .inline-preview-flow {
   column-width: var(--preview-page-width);
   column-gap: var(--preview-page-gap);
+  column-fill: auto;
   height: var(--preview-page-height);
   width: 100%;
   max-width: 100%;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix inline paged preview so multi-page content fills columns sequentially instead of balancing across visible columns
- align inline page overflow behavior with classic mode by applying `column-fill: auto` in paged layouts

fixes #32

## Testing
- `node --check js/builders/inline.js`
- `node --check js/global.js`
- `node --check js/builders/classic.js`
- manual inline editor test at 100% zoom with content spanning multiple pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51cbe264-0866-48bd-bdab-61a60ede7491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51cbe264-0866-48bd-bdab-61a60ede7491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

