### PR TITLE
Refactor global init flow to reduce cyclomatic complexity

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1944,7 +1944,10 @@ function bindEditorAndTemplateListeners () {
     dom.templateGalleryBackBtn.addEventListener('click', showEditor)
   }
   if (dom.templateGalleryGrid) {
-    dom.templateGalleryGrid.addEventListener('click', handleTemplateGalleryGridClick)
+    dom.templateGalleryGrid.addEventListener(
+      'click',
+      handleTemplateGalleryGridClick
+    )
   }
 }
 


### PR DESCRIPTION
### Motivation
- The original `init()` in `js/global.js` had a very high cyclomatic complexity (init ~26) which made it hard to read and triggered static-analysis warnings.
- The change aims to reduce complexity and improve maintainability by extracting grouped responsibilities into focused helpers while preserving startup behavior.

### Description
- Split the monolithic `init()` into small, focused binding functions such as `bindMainInfoListeners`, `bindTopToolbarListeners`, `bindToastModalListeners`, `bindTextModalListeners`, `bindIconModalListeners`, `bindSettingsModalListeners`, `bindPrintModalListeners`, `bindClearAndCloseTabModalListeners`, `bindEditorAndTemplateListeners`, `bindFloatingAddButtonListeners`, `bindCoreEditorListeners`, and `bindPreviewResizeListener`.
- Extracted inline callbacks into named helpers `handleImportDocumentChange` and `handlePrintConfirmClick` to reduce nested branching inside `init()`.
- Moved initial UI setup into `performInitialRender()` and introduced `initializePreviewModeSetting()` to centralize preview defaults.
- Replaced the original `init()` body with a simple orchestrator that calls these helpers in the same order to preserve existing behavior and event wiring.

### Testing
- Ran `node --check js/global.js` to validate syntax and the file passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c098c318cc8321a048f46f7b1558c0)